### PR TITLE
use ascii_letters to increase max params

### DIFF
--- a/src/scim2_filter_parser/transpilers/sql.py
+++ b/src/scim2_filter_parser/transpilers/sql.py
@@ -180,9 +180,9 @@ class Transpiler(ast.NodeTransformer):
 
     def get_next_id(self):
         index = len(self.params)
-        if index >= len(string.ascii_lowercase):
+        if index >= len(string.ascii_letters):
             raise IndexError('Too many params in query. Can not store all of them.')
-        return string.ascii_lowercase[index]
+        return string.ascii_letters[index]
 
     def lookup_op(self, node_value):
         op_code = node_value.lower()


### PR DESCRIPTION
Hi there. 
I'm proposing a change the params dict key to use ascii_letters. Current code use ascii_lowercase and we hits the  params limit. By using ascii_letters, we can store up to 52 params in a query. I'm open for suggestion if there's a better approach.