### PR TITLE
fixing the attribute name grammar

### DIFF
--- a/src/scim2_filter_parser/lexer.py
+++ b/src/scim2_filter_parser/lexer.py
@@ -175,7 +175,7 @@ class SCIMLexer(Lexer):
 
     ignore = ' \t'
 
-    @_(r'\.[a-zA-Z][a-zA-Z0-9_-]*')
+    @_(r'\.[a-zA-Z$][a-zA-Z0-9_$-]*')
     def SUBATTR(self, t):
         t.value = t.value.lstrip('.')
         return t
@@ -200,7 +200,7 @@ class SCIMLexer(Lexer):
         t.value = t.value.rstrip(':')
         return t
 
-    ATTRNAME = r'[a-zA-Z][a-zA-Z0-9_-]*'
+    ATTRNAME = r'[a-zA-Z$][a-zA-Z0-9_$-]*'
 
     # Attribute Operators
     ATTRNAME['eq'] = EQ

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -242,6 +242,36 @@ class RFCExamples(TestCase):
         ]
         self.assertTokens(query, expected)
 
+    def test_attribute_name_with_dollar_char(self):
+        query = 'manager.$ref eq "/v2/Users/a"'
+        expected = [
+            ('ATTRNAME', 'manager'),
+            ('SUBATTR', '$ref'),
+            ('EQ', 'eq'),
+            ('COMP_VALUE', '/v2/Users/a')
+        ]
+        self.assertTokens(query, expected)
+
+    def test_attribute_name_with_dollar_char_complex_query(self):
+        query = 'manager[$ref eq "/v2/Users/q" and value eq "q"] or userName eq "tom"'
+        expected = [
+            ('ATTRNAME', 'manager'),
+            ('LBRACKET', '['),
+            ('ATTRNAME', '$ref'),
+            ('EQ', 'eq'),
+            ('COMP_VALUE', '/v2/Users/q'),
+            ('AND', 'and'),
+            ('ATTRNAME', 'value'),
+            ('EQ', 'eq'),
+            ('COMP_VALUE', 'q'),
+            ('RBRACKET', ']'),
+            ('OR', 'or'),
+            ('ATTRNAME', 'userName'),
+            ('EQ', 'eq'),
+            ('COMP_VALUE', 'tom')
+        ]
+        self.assertTokens(query, expected)
+
 
 class RegressionTestQueries(TestCase):
     def setUp(self):


### PR DESCRIPTION
The following is the fix for [this issue](https://github.com/15five/scim2-filter-parser/issues/25).
Please review.