### PR TITLE
Upgrade sly to 0.5

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - run: pip install tox poetry
+      - run: pip install -U tox poetry
       - run: tox -e flake8
 
   coverage:

--- a/poetry.lock
+++ b/poetry.lock
@@ -442,17 +442,15 @@ files = [
 
 [[package]]
 name = "sly"
-version = "0.4"
-description = "SLY - Sly Lex Yacc"
+version = "0.5"
+description = "\"SLY - Sly Lex Yacc\""
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "sly-0.4.tar.gz", hash = "sha256:e5f2266a231322cc17519fbc3a3ba1c6335fed5a9a55abe0e598a35aea0ac32a"},
+    {file = "sly-0.5-py3-none-any.whl", hash = "sha256:20485483259eec7f6ba85ff4d2e96a4e50c6621902667fc2695cc8bc2a3e5133"},
+    {file = "sly-0.5.tar.gz", hash = "sha256:251d42015e8507158aec2164f06035df4a82b0314ce6450f457d7125e7649024"},
 ]
-
-[package.extras]
-test = ["pytest", "regex"]
 
 [[package]]
 name = "sqlparse"
@@ -572,4 +570,4 @@ django-query = ["django"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "01e13413a2caf3ba85b483cdc742851953f2365a2a56c97af50536a52ea88922"
+content-hash = "05c7a4b0258ed6f0c07a51d669175c0be5cad86e574b1d6e1611312cbb1cdd72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scim2-filter-parser"
-version = "0.4.2"
+version = "0.5.0"
 description = "A customizable parser/transpiler for SCIM2.0 filters."
 license = "MIT"
 authors = ["Paul Logston <paul@15five.com>"]
@@ -36,7 +36,7 @@ sfp-query = 'scim2_filter_parser.queries.sql:main'
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-sly = "==0.4"
+sly = "==0.5"
 
 django = { version = ">=3.2", optional = true }
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -442,9 +442,9 @@ class CommandLine(TestCase):
         lexer.main(['userName eq "bjensen"'])
         result = self.test_stdout.getvalue().strip().split('\n')
         expected = [
-            "Token(type='ATTRNAME', value='userName', lineno=1, index=0)",
-            "Token(type='EQ', value='eq', lineno=1, index=9)",
-            "Token(type='COMP_VALUE', value='bjensen', lineno=1, index=12)",
+            "Token(type='ATTRNAME', value='userName', lineno=1, index=0, end=8)",
+            "Token(type='EQ', value='eq', lineno=1, index=9, end=11)",
+            "Token(type='COMP_VALUE', value='bjensen', lineno=1, index=12, end=21)",
         ]
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
This commit upgrades sly to 0.5. This is the last version of sly that will be published to PyPI per the author of that library. Future versions of sly will only contain bug fixes.

Closes #35. 