### PR TITLE
Replace poetry with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,5 +58,5 @@ line-length = 100
 skip-string-normalization = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
In [nixpkgs](https://github.com/NixOS/nixpkgs), we build Python packages using [build](https://pypa-build.readthedocs.io/en/stable/) instead of poetry, and so we only need to use the more lightweight poetry-core as the PEP 517 build backend.