### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: python:3.11-bullseye
+      image: python:3.12-bullseye
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: python:3.11-bullseye
+      image: python:3.12-bullseye
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGE LOG
 ==========
 
+0.5.1
+-----
+- Add support for Python 3.12
+
+0.5.0
+-----
+
 0.4.2
 -----
 - Drop support for Python 3.7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scim2-filter-parser"
-version = "0.5.0"
+version = "0.5.1"
 description = "A customizable parser/transpiler for SCIM2.0 filters."
 license = "MIT"
 authors = ["Paul Logston <paul@15five.com>"]
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Internet",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py39
     py310
     py311
+    py312
     flake8
     coverage
 
@@ -13,7 +14,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311, flake8
+    3.11: flake8
+    3.12: py312, flake8
 
 [testenv]
 setenv =
@@ -23,6 +25,7 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
     .package: python3
 allowlist_externals = poetry
 commands =
@@ -31,14 +34,14 @@ commands =
 
 [testenv:flake8]
 basepython =
-    python3.11
+    python3.12
 commands =
     poetry install -v --extras "django-query"
     poetry run flake8 src
 
 [testenv:coverage]
 basepython =
-    python3.11
+    python3.12
 commands =
     poetry install -v --extras "django-query"
     poetry run pytest --cov=scim2_filter_parser --cov-report=xml --cov-report=term


### PR DESCRIPTION
It's currently impossible to install `django-scim2` into a venv that
uses Python 3.12, because none of the published versions of this package
support Python 3.12.

Add explicit support for 3.12!

We need to upgrade `tox` to a newer version in order to run on Python
3.12, so let's do that now.