### PR TITLE
Autoformat Python source with ruff format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,15 +13,15 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('../src/'))
+sys.path.insert(0, os.path.abspath("../src/"))
 
-master_doc = 'index'
+master_doc = "index"
 
 # -- Project information -----------------------------------------------------
 
-project = 'scim2-filter-parser'
-copyright = '2019, Paul Logston'
-author = 'Paul Logston'
+project = "scim2-filter-parser"
+copyright = "2019, Paul Logston"
+author = "Paul Logston"
 
 
 # -- General configuration ---------------------------------------------------
@@ -30,16 +30,16 @@ author = 'Paul Logston'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    "sphinx.ext.autodoc",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -47,9 +47,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ select = [
 ]
 
 ignore = [
-  # Line length can largely just be handled by an autoformatter.
-  # Consider making `ruff format` part of CI!
+  # Just let line length be handled by the autoformatter
   "E501",
 ]
 
@@ -86,10 +85,6 @@ pytest-cov = "3.0.0"
 ruff = "^0.4.4"
 toml = "^0.10.1"
 tox = "^3.16.1"
-
-[tool.black]
-line-length = 100
-skip-string-normalization = true
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/speed_test.py
+++ b/speed_test.py
@@ -5,26 +5,26 @@ def short():
     filter = 'userName eq "test"'
 
     attr_map = {
-        ('name', 'familyname', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('username', None, None): 'username',
-        ('title', None, None): 'title',
-        ('usertype', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('username', None, 'urn:ietf:params:scim:schemas:core:2.0:user'): 'username',
-        ('meta', 'lastmodified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyname", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("username", None, None): "username",
+        ("title", None, None): "title",
+        ("usertype", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("username", None, "urn:ietf:params:scim:schemas:core:2.0:user"): "username",
+        ("meta", "lastmodified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
 
     joins = (
-        'LEFT JOIN emails ON emails.user_id = users.id',
-        'LEFT JOIN schemas ON schemas.user_id = users.id',
+        "LEFT JOIN emails ON emails.user_id = users.id",
+        "LEFT JOIN schemas ON schemas.user_id = users.id",
     )
 
-    q = SQLiteQuery(filter, 'users', attr_map, joins)
+    q = SQLiteQuery(filter, "users", attr_map, joins)
 
     q.sql
 
@@ -33,26 +33,25 @@ def long():
     filter = 'emails[type eq "work" and value co "@example.com"] or ims[type eq "xmpp" and value co "@foo.com"]'
 
     attr_map = {
-        ('name', 'familyname', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('username', None, None): 'username',
-        ('title', None, None): 'title',
-        ('usertype', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('username', None, 'urn:ietf:params:scim:schemas:core:2.0:user'): 'username',
-        ('meta', 'lastmodified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyname", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("username", None, None): "username",
+        ("title", None, None): "title",
+        ("usertype", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("username", None, "urn:ietf:params:scim:schemas:core:2.0:user"): "username",
+        ("meta", "lastmodified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
 
     joins = (
-        'LEFT JOIN emails ON emails.user_id = users.id',
-        'LEFT JOIN schemas ON schemas.user_id = users.id',
+        "LEFT JOIN emails ON emails.user_id = users.id",
+        "LEFT JOIN schemas ON schemas.user_id = users.id",
     )
 
-    q = SQLiteQuery(filter, 'users', attr_map, joins)
+    q = SQLiteQuery(filter, "users", attr_map, joins)
 
     q.sql
-

--- a/src/scim2_filter_parser/attr_paths.py
+++ b/src/scim2_filter_parser/attr_paths.py
@@ -29,6 +29,7 @@ values of a complex multi-valued attribute to be selected::
 The classes in this module parse the overall PATH string for its parts so
 that they can be easily used in following code.
 """
+
 import json
 import string
 
@@ -41,6 +42,7 @@ class AttrPath:
     """
     This class depends on the SQL transpiler.
     """
+
     def __init__(self, filter_: str, attr_map: dict):
         """
         Perform parsing of path.
@@ -101,35 +103,35 @@ class AttrPath:
         return iter(self.transpiler.attr_paths)
 
     def __str__(self) -> str:
-        return json.dumps(self.transpiler.attr_paths, sort_keys=True, indent='    ')
+        return json.dumps(self.transpiler.attr_paths, sort_keys=True, indent="    ")
 
 
 def main(argv=None):
-    '''
+    """
     Main program. Used for testing.
-    '''
+    """
     import argparse
     import sys
 
     argv = argv or sys.argv[1:]
 
-    parser = argparse.ArgumentParser('SCIM 2.0 Filter Parser Transpiler')
-    parser.add_argument('filter', help="""Eg. 'userName eq "bjensen"'""")
+    parser = argparse.ArgumentParser("SCIM 2.0 Filter Parser Transpiler")
+    parser.add_argument("filter", help="""Eg. 'userName eq "bjensen"'""")
     args = parser.parse_args(argv)
 
     attr_map = {
-        ('name', 'familyname', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('userName', None, None): 'username',
-        ('title', None, None): 'title',
-        ('userType', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'username',
-        ('meta', 'lastModified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyname", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("userName", None, None): "username",
+        ("title", None, None): "title",
+        ("userType", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "username",
+        ("meta", "lastModified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
 
     q = AttrPath(args.filter, attr_map)
@@ -137,5 +139,5 @@ def main(argv=None):
     print(q)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/scim2_filter_parser/lexer.py
+++ b/src/scim2_filter_parser/lexer.py
@@ -138,6 +138,7 @@ See https://tools.ietf.org/html/rfc7644#section-3.4.2.2 for more details.
                         Table 5: Grouping Operators
 
 """
+
 # ruff: noqa: F821
 from sly import Lexer
 
@@ -145,19 +146,28 @@ from sly import Lexer
 class SCIMLexer(Lexer):
     tokens = {
         # Attribute Operators
-        EQ, NE,
-        GT, GE, LT, LE,
-        CO, SW, EW, PR,
-
+        EQ,
+        NE,
+        GT,
+        GE,
+        LT,
+        LE,
+        CO,
+        SW,
+        EW,
+        PR,
         # Logical Operators
-        AND, OR, NOT,
-        FALSE, TRUE,
+        AND,
+        OR,
+        NOT,
+        FALSE,
+        TRUE,
         NULL,
-
         # Grouping Operators
-        LPAREN, RPAREN,
-        LBRACKET, RBRACKET,
-
+        LPAREN,
+        RPAREN,
+        LBRACKET,
+        RBRACKET,
         # Other
         NUMBER,
         COMP_VALUE,
@@ -173,113 +183,113 @@ class SCIMLexer(Lexer):
     #     which takes precedence over "or"
     # 3.  Attribute operators
 
-    ignore = ' \t'
+    ignore = " \t"
 
-    @_(r'\.[a-zA-Z$][a-zA-Z0-9_$-]*')
+    @_(r"\.[a-zA-Z$][a-zA-Z0-9_$-]*")
     def SUBATTR(self, t):
-        t.value = t.value.lstrip('.')
+        t.value = t.value.lstrip(".")
         return t
 
     # Grouping Operators
-    LPAREN = r'\('
-    RPAREN = r'\)'
-    LBRACKET = r'\['
-    RBRACKET = r'\]'
+    LPAREN = r"\("
+    RPAREN = r"\)"
+    LBRACKET = r"\["
+    RBRACKET = r"\]"
 
     # compValue literals
     # false / null / true / number / string
     # Rules from https://tools.ietf.org/html/rfc7159
-    FALSE = r'false'
-    TRUE = r'true'
-    NULL = r'null'
-    NUMBER = r'[0-9]' # only support integers at this time
+    FALSE = r"false"
+    TRUE = r"true"
+    NULL = r"null"
+    NUMBER = r"[0-9]"  # only support integers at this time
 
     # attrPath parts
-    @_(r'[a-zA-Z]+:[a-zA-Z0-9:\._-]+:')
+    @_(r"[a-zA-Z]+:[a-zA-Z0-9:\._-]+:")
     def SCHEMA_URI(self, t):
-        t.value = t.value.rstrip(':')
+        t.value = t.value.rstrip(":")
         return t
 
     # "$" is not allowed as part of an ATTRNAME per RFC 7643. It is allowed
     # here so that ATTRNAME can be used in tokenization of a complex query
     # without further complicating the parsing logic with complex query
     # specific tokens.
-    ATTRNAME = r'[a-zA-Z$][a-zA-Z0-9_$-]*'
+    ATTRNAME = r"[a-zA-Z$][a-zA-Z0-9_$-]*"
 
     # Attribute Operators
-    ATTRNAME['eq'] = EQ
-    ATTRNAME['Eq'] = EQ
-    ATTRNAME['eQ'] = EQ
-    ATTRNAME['EQ'] = EQ
+    ATTRNAME["eq"] = EQ
+    ATTRNAME["Eq"] = EQ
+    ATTRNAME["eQ"] = EQ
+    ATTRNAME["EQ"] = EQ
 
-    ATTRNAME['ne'] = NE
-    ATTRNAME['Ne'] = NE
-    ATTRNAME['nE'] = NE
-    ATTRNAME['NE'] = NE
+    ATTRNAME["ne"] = NE
+    ATTRNAME["Ne"] = NE
+    ATTRNAME["nE"] = NE
+    ATTRNAME["NE"] = NE
 
-    ATTRNAME['co'] = CO
-    ATTRNAME['Co'] = CO
-    ATTRNAME['cO'] = CO
-    ATTRNAME['CO'] = CO
+    ATTRNAME["co"] = CO
+    ATTRNAME["Co"] = CO
+    ATTRNAME["cO"] = CO
+    ATTRNAME["CO"] = CO
 
-    ATTRNAME['sw'] = SW
-    ATTRNAME['Sw'] = SW
-    ATTRNAME['sW'] = SW
-    ATTRNAME['SW'] = SW
+    ATTRNAME["sw"] = SW
+    ATTRNAME["Sw"] = SW
+    ATTRNAME["sW"] = SW
+    ATTRNAME["SW"] = SW
 
-    ATTRNAME['ew'] = EW
-    ATTRNAME['Ew'] = EW
-    ATTRNAME['eW'] = EW
-    ATTRNAME['EW'] = EW
+    ATTRNAME["ew"] = EW
+    ATTRNAME["Ew"] = EW
+    ATTRNAME["eW"] = EW
+    ATTRNAME["EW"] = EW
 
-    ATTRNAME['pr'] = PR
-    ATTRNAME['Pr'] = PR
-    ATTRNAME['pR'] = PR
-    ATTRNAME['PR'] = PR
+    ATTRNAME["pr"] = PR
+    ATTRNAME["Pr"] = PR
+    ATTRNAME["pR"] = PR
+    ATTRNAME["PR"] = PR
 
-    ATTRNAME['gt'] = GT
-    ATTRNAME['Gt'] = GT
-    ATTRNAME['gT'] = GT
-    ATTRNAME['GT'] = GT
+    ATTRNAME["gt"] = GT
+    ATTRNAME["Gt"] = GT
+    ATTRNAME["gT"] = GT
+    ATTRNAME["GT"] = GT
 
-    ATTRNAME['ge'] = GE
-    ATTRNAME['Ge'] = GE
-    ATTRNAME['gE'] = GE
-    ATTRNAME['GE'] = GE
+    ATTRNAME["ge"] = GE
+    ATTRNAME["Ge"] = GE
+    ATTRNAME["gE"] = GE
+    ATTRNAME["GE"] = GE
 
-    ATTRNAME['lt'] = LT
-    ATTRNAME['Lt'] = LT
-    ATTRNAME['lT'] = LT
-    ATTRNAME['LT'] = LT
+    ATTRNAME["lt"] = LT
+    ATTRNAME["Lt"] = LT
+    ATTRNAME["lT"] = LT
+    ATTRNAME["LT"] = LT
 
-    ATTRNAME['le'] = LE
-    ATTRNAME['Le'] = LE
-    ATTRNAME['lE'] = LE
-    ATTRNAME['LE'] = LE
+    ATTRNAME["le"] = LE
+    ATTRNAME["Le"] = LE
+    ATTRNAME["lE"] = LE
+    ATTRNAME["LE"] = LE
 
     # Logical Operators
-    ATTRNAME['and'] = AND
-    ATTRNAME['And'] = AND
-    ATTRNAME['aNd'] = AND
-    ATTRNAME['ANd'] = AND
-    ATTRNAME['anD'] = AND
-    ATTRNAME['AnD'] = AND
-    ATTRNAME['aND'] = AND
-    ATTRNAME['AND'] = AND
+    ATTRNAME["and"] = AND
+    ATTRNAME["And"] = AND
+    ATTRNAME["aNd"] = AND
+    ATTRNAME["ANd"] = AND
+    ATTRNAME["anD"] = AND
+    ATTRNAME["AnD"] = AND
+    ATTRNAME["aND"] = AND
+    ATTRNAME["AND"] = AND
 
-    ATTRNAME['or'] = OR
-    ATTRNAME['Or'] = OR
-    ATTRNAME['oR'] = OR
-    ATTRNAME['OR'] = OR
+    ATTRNAME["or"] = OR
+    ATTRNAME["Or"] = OR
+    ATTRNAME["oR"] = OR
+    ATTRNAME["OR"] = OR
 
-    ATTRNAME['not'] = NOT
-    ATTRNAME['Not'] = NOT
-    ATTRNAME['nOt'] = NOT
-    ATTRNAME['NOt'] = NOT
-    ATTRNAME['noT'] = NOT
-    ATTRNAME['NoT'] = NOT
-    ATTRNAME['nOT'] = NOT
-    ATTRNAME['NOT'] = NOT
+    ATTRNAME["not"] = NOT
+    ATTRNAME["Not"] = NOT
+    ATTRNAME["nOt"] = NOT
+    ATTRNAME["NOt"] = NOT
+    ATTRNAME["noT"] = NOT
+    ATTRNAME["NoT"] = NOT
+    ATTRNAME["nOT"] = NOT
+    ATTRNAME["NOT"] = NOT
 
     @_(r'"([^"]*)"')
     def COMP_VALUE(self, t):
@@ -291,16 +301,16 @@ class SCIMLexer(Lexer):
 
 
 def main(argv=None):
-    '''
+    """
     Main program. Used for testing.
-    '''
+    """
     import argparse
     import sys
 
     argv = argv or sys.argv[1:]
 
-    parser = argparse.ArgumentParser('SCIM 2.0 Filter Parser Lexer')
-    parser.add_argument('filter', help="""Eg. 'userName eq "bjensen"'""")
+    parser = argparse.ArgumentParser("SCIM 2.0 Filter Parser Lexer")
+    parser.add_argument("filter", help="""Eg. 'userName eq "bjensen"'""")
     args = parser.parse_args(argv)
 
     token_stream = SCIMLexer().tokenize(args.filter)
@@ -308,6 +318,5 @@ def main(argv=None):
         print(token)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-

--- a/src/scim2_filter_parser/queries/sql.py
+++ b/src/scim2_filter_parser/queries/sql.py
@@ -1,13 +1,14 @@
 """
 The logic in this module builds a full SQL query based on a SCIM filter.
 """
+
 from ..lexer import SCIMLexer
 from ..parser import SCIMParser
 from ..transpilers.sql import Transpiler
 
 
 class SQLQuery:
-    placeholder = '%s'
+    placeholder = "%s"
 
     def __init__(self, filter_, table_name, attr_map, joins=()):
         self.filter: str = filter_
@@ -31,14 +32,17 @@ class SQLQuery:
 
     @property
     def params(self):
-        return [self.params_dict[k] for k, _v in sorted(self.params_dict.items())
-                if self.params_dict[k] is not None]
+        return [
+            self.params_dict[k]
+            for k, _v in sorted(self.params_dict.items())
+            if self.params_dict[k] is not None
+        ]
 
     @property
     def sql(self) -> str:
         lines = [
-            f'SELECT DISTINCT {self.table_name}.*',
-            f'FROM {self.table_name}',
+            f"SELECT DISTINCT {self.table_name}.*",
+            f"FROM {self.table_name}",
         ]
 
         if self.joins:
@@ -50,69 +54,71 @@ class SQLQuery:
 
         if self.where_sql:
             where_sql = self.where_sql.format(**placeholders)
-            lines.append(f'WHERE {where_sql}')
+            lines.append(f"WHERE {where_sql}")
 
-        lines[-1] += ';'  # Complete all SQL with semicolon
+        lines[-1] += ";"  # Complete all SQL with semicolon
 
-        return '\n'.join('    ' + line for line in lines)
+        return "\n".join("    " + line for line in lines)
 
     def __str__(self) -> str:
         orig_placeholder = self.placeholder
-        self.placeholder = '{}'
+        self.placeholder = "{}"
         sql = self.sql.format(*self.params)
         self.placeholder = orig_placeholder
 
         # Wrap the SQL in invalid characters so users don't accidentally
         # walk into a SQL Injection vulnerability.
-        return '\n'.join((
-            '>>> DO NOT USE THIS OUTPUT DIRECTLY',
-            '>>> SQL INJECTION ATTACK RISK',
-            '>>> SQL PREVIEW:',
-            sql,
-        ))
+        return "\n".join(
+            (
+                ">>> DO NOT USE THIS OUTPUT DIRECTLY",
+                ">>> SQL INJECTION ATTACK RISK",
+                ">>> SQL PREVIEW:",
+                sql,
+            )
+        )
 
 
 class SQLiteQuery(SQLQuery):
-    placeholder = '?'
+    placeholder = "?"
 
 
 def main(argv=None):
-    '''
+    """
     Main program. Used for testing.
-    '''
+    """
     import argparse
     import sys
 
     argv = argv or sys.argv[1:]
 
-    parser = argparse.ArgumentParser('SCIM 2.0 Filter Parser Transpiler')
-    parser.add_argument('filter', help="""Eg. 'userName eq "bjensen"'""")
+    parser = argparse.ArgumentParser("SCIM 2.0 Filter Parser Transpiler")
+    parser.add_argument("filter", help="""Eg. 'userName eq "bjensen"'""")
     args = parser.parse_args(argv)
 
     attr_map = {
-        ('name', 'familyname', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('userName', None, None): 'username',
-        ('title', None, None): 'title',
-        ('userType', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'username',
-        ('meta', 'lastModified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyname", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("userName", None, None): "username",
+        ("title", None, None): "title",
+        ("userType", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "username",
+        ("meta", "lastModified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
 
     joins = (
-        'LEFT JOIN emails ON emails.user_id = users.id',
-        'LEFT JOIN schemas ON schemas.user_id = users.id',
+        "LEFT JOIN emails ON emails.user_id = users.id",
+        "LEFT JOIN schemas ON schemas.user_id = users.id",
     )
 
-    q = SQLiteQuery(args.filter, 'users', attr_map, joins)
+    q = SQLiteQuery(args.filter, "users", attr_map, joins)
 
     print(q)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/scim2_filter_parser/transpilers/django_q_object.py
+++ b/src/scim2_filter_parser/transpilers/django_q_object.py
@@ -1,6 +1,7 @@
 """
 The logic in this module builds a Django Q object from an SCIM filter.
 """
+
 import ast
 from typing import Mapping
 
@@ -8,7 +9,10 @@ try:
     from django.db.models import Q
 except ImportError:
     import warnings
-    warnings.warn('Django not installed but Django Q Transpiler in use. Please install Django.')
+
+    warnings.warn(
+        "Django not installed but Django Q Transpiler in use. Please install Django."
+    )
 
     class Q:
         def __init__(self, *args, **kwargs):
@@ -22,6 +26,7 @@ except ImportError:
 
         def __invert__(self):
             return self
+
 
 from scim2_filter_parser import ast as scim2ast
 from scim2_filter_parser.lexer import SCIMLexer

--- a/src/scim2_filter_parser/transpilers/sql.py
+++ b/src/scim2_filter_parser/transpilers/sql.py
@@ -2,36 +2,38 @@
 The logic in this module builds a portion of a WHERE SQL
 clause based on a SCIM filter.
 """
+
 import ast
 import collections
 import string
 
 from .. import ast as scim2ast
 
-AttrPath = collections.namedtuple('AttrPath', ['attr_name', 'sub_attr', 'uri'])
+AttrPath = collections.namedtuple("AttrPath", ["attr_name", "sub_attr", "uri"])
 
 
 class Transpiler(ast.NodeTransformer):
     """
     Transpile a SCIM AST into a SQL WHERE clause (not including the "WHERE" keyword)
     """
+
     binary_op_by_scim_op = {
-        'eq': '=',
-        'ne': '!=',
-        'co': 'LIKE',
-        'sw': 'LIKE',
-        'ew': 'LIKE',
-        'pr': 'IS NOT NULL',
-        'gt': '>',
-        'ge': '>=',
-        'lt': '<',
-        'le': '<=',
+        "eq": "=",
+        "ne": "!=",
+        "co": "LIKE",
+        "sw": "LIKE",
+        "ew": "LIKE",
+        "pr": "IS NOT NULL",
+        "gt": ">",
+        "ge": ">=",
+        "lt": "<",
+        "le": "<=",
     }
 
     matching_op_by_scim_op = {
-        'co': ('%', '%'),
-        'sw': ('', '%'),
-        'ew': ('%', ''),
+        "co": ("%", "%"),
+        "sw": ("", "%"),
+        "ew": ("%", ""),
     }
 
     def __init__(self, attr_map, *args, **kwargs):
@@ -50,23 +52,33 @@ class Transpiler(ast.NodeTransformer):
         if node.namespace:
             # push the namespace from value path down the tree
             if isinstance(node.expr, scim2ast.Filter):
-                node.expr = scim2ast.Filter(node.expr.expr, node.expr.negated, node.namespace)
+                node.expr = scim2ast.Filter(
+                    node.expr.expr, node.expr.negated, node.namespace
+                )
             elif isinstance(node.expr, scim2ast.LogExpr):
-                expr1 = scim2ast.Filter(node.expr.expr1.expr, node.expr.expr1.negated, node.namespace)
-                expr2 = scim2ast.Filter(node.expr.expr2.expr, node.expr.expr2.negated, node.namespace)
+                expr1 = scim2ast.Filter(
+                    node.expr.expr1.expr, node.expr.expr1.negated, node.namespace
+                )
+                expr2 = scim2ast.Filter(
+                    node.expr.expr2.expr, node.expr.expr2.negated, node.namespace
+                )
                 node.expr = scim2ast.LogExpr(node.expr.op, expr1, expr2)
             elif isinstance(node.expr, scim2ast.AttrExpr):
                 # namespace takes place of previous attr_name in attr_path
                 sub_attr = scim2ast.SubAttr(node.expr.attr_path.attr_name)
-                attr_path = scim2ast.AttrPath(node.namespace.attr_name, sub_attr, node.expr.attr_path.uri)
-                node.expr = scim2ast.AttrExpr(node.expr.value, attr_path, node.expr.comp_value)
+                attr_path = scim2ast.AttrPath(
+                    node.namespace.attr_name, sub_attr, node.expr.attr_path.uri
+                )
+                node.expr = scim2ast.AttrExpr(
+                    node.expr.value, attr_path, node.expr.comp_value
+                )
             else:
-                raise NotImplementedError(f'Node {node} can not pass on namespace')
+                raise NotImplementedError(f"Node {node} can not pass on namespace")
 
         expr = self.visit(node.expr)
 
         if expr and node.negated:
-            expr = f'NOT ({expr})'
+            expr = f"NOT ({expr})"
 
         return expr
 
@@ -76,7 +88,7 @@ class Transpiler(ast.NodeTransformer):
         op = node.op.upper()
 
         if expr1 and expr2:
-            return f'({expr1}) {op} ({expr2})'
+            return f"({expr1}) {op} ({expr2})"
         elif expr1:
             return expr1
         elif expr2:
@@ -113,12 +125,12 @@ class Transpiler(ast.NodeTransformer):
             full, partial = self.visit_PartialAttrExpr(node.attr_path.attr_name)
             if full and partial:
                 value = self.visit_AttrExprValue(node)
-                return f'({full} AND {partial} {value})'
+                return f"({full} AND {partial} {value})"
             elif full:
                 return full
             elif partial:
                 value = self.visit_AttrExprValue(node)
-                return f'{partial} {value}'
+                return f"{partial} {value}"
             else:
                 return None
         else:
@@ -134,9 +146,9 @@ class Transpiler(ast.NodeTransformer):
             value = self.visit_AttrExprValue(node)
 
             if node.case_insensitive:
-                return f'UPPER({attr}) {value}'
+                return f"UPPER({attr}) {value}"
 
-            return f'{attr} {value}'
+            return f"{attr} {value}"
 
     def visit_AttrExprValue(self, node):
         op_sql = self.lookup_op(node.value)
@@ -150,7 +162,7 @@ class Transpiler(ast.NodeTransformer):
         # There is a comp_value, so visit node and build SQL.
 
         # prep item_id to be a str replacement placeholder
-        item_id_placeholder = '{' + item_id + '}'
+        item_id_placeholder = "{" + item_id + "}"
 
         if node.value.lower() in self.matching_op_by_scim_op.keys():
             # Add appropriate % signs to values in LIKE clause
@@ -163,9 +175,9 @@ class Transpiler(ast.NodeTransformer):
         self.params[item_id] = value
 
         if node.case_insensitive:
-            return f'{op_sql} UPPER({item_id_placeholder})'
+            return f"{op_sql} UPPER({item_id_placeholder})"
 
-        return f'{op_sql} {item_id_placeholder}'
+        return f"{op_sql} {item_id_placeholder}"
 
     def visit_AttrPath(self, node):
         attr_name_value = node.attr_name
@@ -185,7 +197,7 @@ class Transpiler(ast.NodeTransformer):
         return self.attr_map.get(attr_path_tuple)
 
     def visit_CompValue(self, node):
-        if node.value in ('true', 'false', 'null'):
+        if node.value in ("true", "false", "null"):
             return node.value.upper()
 
         # TODO: Handle timestamps!
@@ -195,7 +207,7 @@ class Transpiler(ast.NodeTransformer):
     def get_next_id(self):
         index = len(self.params)
         if index >= len(string.ascii_lowercase):
-            raise IndexError('Too many params in query. Can not store all of them.')
+            raise IndexError("Too many params in query. Can not store all of them.")
         return string.ascii_lowercase[index]
 
     def lookup_op(self, node_value):
@@ -204,7 +216,7 @@ class Transpiler(ast.NodeTransformer):
         sql = self.binary_op_by_scim_op.get(op_code)
 
         if not sql:
-            raise ValueError(f'Unknown SQL op {op_code}')
+            raise ValueError(f"Unknown SQL op {op_code}")
 
         return sql or node_value
 
@@ -214,15 +226,15 @@ class Transpiler(ast.NodeTransformer):
         sql = self.matching_op_by_scim_op.get(op_code)
 
         if not sql:
-            raise ValueError(f'Unknown SQL LIKE op {op_code}')
+            raise ValueError(f"Unknown SQL LIKE op {op_code}")
 
         return sql
 
 
 def main(argv=None):
-    '''
+    """
     Main program. Used for testing.
-    '''
+    """
     import argparse
     import sys
 
@@ -231,32 +243,31 @@ def main(argv=None):
 
     argv = argv or sys.argv[1:]
 
-    parser = argparse.ArgumentParser('SCIM 2.0 Filter Parser Transpiler')
-    parser.add_argument('filter', help="""Eg. 'userName eq "bjensen"'""")
+    parser = argparse.ArgumentParser("SCIM 2.0 Filter Parser Transpiler")
+    parser.add_argument("filter", help="""Eg. 'userName eq "bjensen"'""")
     args = parser.parse_args(argv)
 
     token_stream = SCIMLexer().tokenize(args.filter)
     ast = SCIMParser().parse(token_stream)
     attr_map = {
-        ('name', 'familyname', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('userName', None, None): 'username',
-        ('title', None, None): 'title',
-        ('userType', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'username',
-        ('meta', 'lastModified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyname", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("userName", None, None): "username",
+        ("title", None, None): "title",
+        ("userType", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "username",
+        ("meta", "lastModified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
     sql, params = Transpiler(attr_map).transpile(ast)
 
-    print('SQL:', sql)
-    print('PARAMS:', params)
+    print("SQL:", sql)
+    print("PARAMS:", params)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-

--- a/tests/test_attr_paths.py
+++ b/tests/test_attr_paths.py
@@ -20,27 +20,27 @@ class TestAttrPathMixin:
 
 class RFCExamples(TestAttrPathMixin, TestCase):
     attr_map = {
-        ('name', 'familyName', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('userName', None, None): 'username',
-        ('title', None, None): 'title',
-        ('userType', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'username',
-        ('meta', 'lastModified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyName", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("userName", None, None): "username",
+        ("title", None, None): "title",
+        ("userType", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "username",
+        ("meta", "lastModified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
 
     def test_username_eq(self):
         query = 'userName eq "bjensen"'
         attr_paths = [
-            ('userName', None, None),
+            ("userName", None, None),
         ]
         params_dict = {
-            ('userName', None, None): 'bjensen',
+            ("userName", None, None): "bjensen",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -48,10 +48,10 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_family_name_contains(self):
         query = '''name.familyName co "O'Malley"'''
         attr_paths = [
-            ('name', 'familyName', None),
+            ("name", "familyName", None),
         ]
         params_dict = {
-            ('name', 'familyName', None): "%O'Malley%",
+            ("name", "familyName", None): "%O'Malley%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -59,10 +59,10 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_username_startswith(self):
         query = 'userName sw "J"'
         attr_paths = [
-            ('userName', None, None),
+            ("userName", None, None),
         ]
         params_dict = {
-            ('userName', None, None): 'J%',
+            ("userName", None, None): "J%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -70,21 +70,21 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_schema_username_startswith(self):
         query = 'urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"'
         attr_paths = [
-            ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'),
+            ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"),
         ]
         params_dict = {
-            ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'J%',
+            ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "J%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_title_has_value(self):
-        query = 'title pr'
+        query = "title pr"
         attr_paths = [
-            ('title', None, None),
+            ("title", None, None),
         ]
         params_dict = {
-            ('title', None, None): None,
+            ("title", None, None): None,
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -92,56 +92,48 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_meta_last_modified_gt(self):
         query = 'meta.lastModified gt "2011-05-13T04:42:34Z"'
         attr_paths = [
-            ('meta', 'lastModified', None),
+            ("meta", "lastModified", None),
         ]
-        params_dict = {
-            ('meta', 'lastModified', None): '2011-05-13T04:42:34Z'
-        }
+        params_dict = {("meta", "lastModified", None): "2011-05-13T04:42:34Z"}
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_meta_last_modified_ge(self):
         query = 'meta.lastModified ge "2011-05-13T04:42:34Z"'
         attr_paths = [
-            ('meta', 'lastModified', None),
+            ("meta", "lastModified", None),
         ]
-        params_dict = {
-            ('meta', 'lastModified', None): '2011-05-13T04:42:34Z'
-        }
+        params_dict = {("meta", "lastModified", None): "2011-05-13T04:42:34Z"}
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_meta_last_modified_lt(self):
         query = 'meta.lastModified lt "2011-05-13T04:42:34Z"'
         attr_paths = [
-            ('meta', 'lastModified', None),
+            ("meta", "lastModified", None),
         ]
-        params_dict = {
-            ('meta', 'lastModified', None): '2011-05-13T04:42:34Z'
-        }
+        params_dict = {("meta", "lastModified", None): "2011-05-13T04:42:34Z"}
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_meta_last_modified_le(self):
         query = 'meta.lastModified le "2011-05-13T04:42:34Z"'
         attr_paths = [
-            ('meta', 'lastModified', None),
+            ("meta", "lastModified", None),
         ]
-        params_dict = {
-            ('meta', 'lastModified', None): '2011-05-13T04:42:34Z'
-        }
+        params_dict = {("meta", "lastModified", None): "2011-05-13T04:42:34Z"}
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_title_has_value_and_user_type_eq(self):
         query = 'title pr and userType eq "Employee"'
         attr_paths = [
-            ('title', None, None),
-            ('userType', None, None),
+            ("title", None, None),
+            ("userType", None, None),
         ]
         params_dict = {
-            ('title', None, None): None,
-            ('userType', None, None): 'Employee',
+            ("title", None, None): None,
+            ("userType", None, None): "Employee",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -149,23 +141,29 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_title_has_value_or_user_type_eq(self):
         query = 'title pr or userType eq "Intern"'
         attr_paths = [
-            ('title', None, None),
-            ('userType', None, None),
+            ("title", None, None),
+            ("userType", None, None),
         ]
         params_dict = {
-            ('title', None, None): None,
-            ('userType', None, None): 'Intern',
+            ("title", None, None): None,
+            ("userType", None, None): "Intern",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_schemas_eq(self):
-        query = 'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        query = (
+            'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        )
         attr_paths = [
-            ('schemas', None, None),
+            ("schemas", None, None),
         ]
         params_dict = {
-            ('schemas', None, None): 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User',
+            (
+                "schemas",
+                None,
+                None,
+            ): "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -173,14 +171,14 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         query = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         attr_paths = [
-            ('userType', None, None),
-            ('emails', None, None),
-            ('emails', 'value', None),
+            ("userType", None, None),
+            ("emails", None, None),
+            ("emails", "value", None),
         ]
         params_dict = {
-            ('userType', None, None): 'Employee',
-            ('emails', None, None): '%example.com%',
-            ('emails', 'value', None): '%example.org%',
+            ("userType", None, None): "Employee",
+            ("emails", None, None): "%example.com%",
+            ("emails", "value", None): "%example.org%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -188,14 +186,14 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         query = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
         attr_paths = [
-            ('userType', None, None),
-            ('emails', None, None),
-            ('emails', 'value', None),
+            ("userType", None, None),
+            ("emails", None, None),
+            ("emails", "value", None),
         ]
         params_dict = {
-            ('userType', None, None): 'Employee',
-            ('emails', None, None): '%example.com%',
-            ('emails', 'value', None): '%example.org%',
+            ("userType", None, None): "Employee",
+            ("emails", None, None): "%example.com%",
+            ("emails", "value", None): "%example.org%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -203,12 +201,12 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_user_type_eq_and_not_email_type_eq(self):
         query = 'userType eq "Employee" and (emails.type eq "work")'
         attr_paths = [
-            ('userType', None, None),
-            ('emails', 'type', None),
+            ("userType", None, None),
+            ("emails", "type", None),
         ]
         params_dict = {
-            ('userType', None, None): 'Employee',
-            ('emails', 'type', None): 'work',
+            ("userType", None, None): "Employee",
+            ("emails", "type", None): "work",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -216,32 +214,34 @@ class RFCExamples(TestAttrPathMixin, TestCase):
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         attr_paths = [
-            ('userType', None, None),
-            ('emails', 'type', None),
-            ('emails', 'value', None),
+            ("userType", None, None),
+            ("emails", "type", None),
+            ("emails", "value", None),
         ]
         params_dict = {
-            ('userType', None, None): 'Employee',
-            ('emails', 'type', None): 'work',
-            ('emails', 'value', None): '%@example.com%',
+            ("userType", None, None): "Employee",
+            ("emails", "type", None): "work",
+            ("emails", "value", None): "%@example.com%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
     def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         attr_paths = [
-            ('emails', 'type', None),
-            ('emails', 'value', None),
-            ('ims', 'type', None),
-            ('ims', 'value', None),
+            ("emails", "type", None),
+            ("emails", "value", None),
+            ("ims", "type", None),
+            ("ims", "value", None),
         ]
         params_dict = {
-            ('emails', 'type', None): 'work',
-            ('emails', 'value', None): '%@example.com%',
-            ('ims', 'type', None): 'xmpp',
-            ('ims', 'value', None): '%@foo.com%',
+            ("emails", "type", None): "work",
+            ("emails", "value", None): "%@example.com%",
+            ("ims", "type", None): "xmpp",
+            ("ims", "value", None): "%@foo.com%",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -249,19 +249,21 @@ class RFCExamples(TestAttrPathMixin, TestCase):
 
 class AzureQueries(TestAttrPathMixin, TestCase):
     attr_map = {
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
     }
 
     def test_email_type_eq_primary_value_eq_uuid(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         attr_paths = [
-            ('emails', 'type', None),
-            ('emails', 'value', None),
+            ("emails", "type", None),
+            ("emails", "value", None),
         ]
         params_dict = {
-            ('emails', 'type', None): 'Primary',
-            ('emails', 'value', None): '001750ca-8202-47cd-b553-c63f4f245940',
+            ("emails", "type", None): "Primary",
+            ("emails", "value", None): "001750ca-8202-47cd-b553-c63f4f245940",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -269,8 +271,8 @@ class AzureQueries(TestAttrPathMixin, TestCase):
 
 class ComplexQueries(TestCase):
     attr_map = {
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
     }
 
     def test_is_not_complex(self):
@@ -279,40 +281,44 @@ class ComplexQueries(TestCase):
         self.assertFalse(attr_paths.is_complex)
 
     def test_is_complex(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         attr_paths = attr_paths_mod.AttrPath(query, self.attr_map)
         self.assertTrue(attr_paths.is_complex)
 
 
 class FirstPathQueries(TestCase):
     attr_map = {
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
     }
 
     def test_not_complex(self):
         query = 'emails.value eq "001750ca-8202-47cd-b553-c63f4f245940"'
         attr_paths = attr_paths_mod.AttrPath(query, self.attr_map)
-        self.assertEqual(attr_paths.first_path, ('emails', 'value', None))
+        self.assertEqual(attr_paths.first_path, ("emails", "value", None))
 
     def test_complex(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         attr_paths = attr_paths_mod.AttrPath(query, self.attr_map)
-        self.assertEqual(attr_paths.first_path, ('emails', 'type', None))
+        self.assertEqual(attr_paths.first_path, ("emails", "type", None))
 
 
 class GroupQueries(TestAttrPathMixin, TestCase):
     attr_map = {
-        ('members', 'value', None): 'members.value',
+        ("members", "value", None): "members.value",
     }
 
     def test_email_type_eq_primary_value_eq_uuid(self):
         query = 'members[value eq "337991"]'
         attr_paths = [
-            ('members', 'value', None),
+            ("members", "value", None),
         ]
         params_dict = {
-            ('members', 'value', None): '337991',
+            ("members", "value", None): "337991",
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
@@ -320,19 +326,18 @@ class GroupQueries(TestAttrPathMixin, TestCase):
     def test_filter_with_eq_pull_correct_values(self):
         query = 'members[value eq "337991"] eq ""'
         attr_paths = [
-            ('members', 'value', None),
-            ('members', None, None),
+            ("members", "value", None),
+            ("members", None, None),
         ]
         params_dict = {
-            ('members', 'value', None): '337991',
-            ('members', None, None): None,
+            ("members", "value", None): "337991",
+            ("members", None, None): None,
         }
         self.assertAttrPath(query, attr_paths)
         self.assertAttrPathParams(query, params_dict)
 
 
 class CommandLine(TestCase):
-
     def setUp(self):
         self.original_stdout = sys.stdout
         sys.stdout = self.test_stdout = StringIO()
@@ -343,5 +348,5 @@ class CommandLine(TestCase):
     def test_command_line(self):
         attr_paths_mod.main(['userName eq "bjensen"'])
         result = self.test_stdout.getvalue().strip()
-        expected = [['userName', None, None]]
+        expected = [["userName", None, None]]
         self.assertEqual(json.loads(result), expected)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -21,254 +21,258 @@ class RFCExamples(TestCase):
     def test_username_eq(self):
         query = 'userName eq "bjensen"'
         expected = [
-            ('ATTRNAME', 'userName'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'bjensen'),
+            ("ATTRNAME", "userName"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "bjensen"),
         ]
         self.assertTokens(query, expected)
 
     def test_family_name_contains(self):
         query = '''name.familyName co "O'Malley"'''
         expected = [
-            ('ATTRNAME', 'name'),
-            ('SUBATTR', 'familyName'),
-            ('CO', 'co'),
-            ('COMP_VALUE', "O'Malley")
+            ("ATTRNAME", "name"),
+            ("SUBATTR", "familyName"),
+            ("CO", "co"),
+            ("COMP_VALUE", "O'Malley"),
         ]
         self.assertTokens(query, expected)
 
     def test_username_startswith(self):
         query = 'userName sw "J"'
         expected = [
-            ('ATTRNAME', 'userName'),
-            ('SW', 'sw'),
-            ('COMP_VALUE', 'J'),
+            ("ATTRNAME", "userName"),
+            ("SW", "sw"),
+            ("COMP_VALUE", "J"),
         ]
         self.assertTokens(query, expected)
 
     def test_schema_username_startswith(self):
         query = 'urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"'
         expected = [
-            ('SCHEMA_URI', 'urn:ietf:params:scim:schemas:core:2.0:User'),
-            ('ATTRNAME', 'userName'),
-            ('SW', 'sw'),
-            ('COMP_VALUE', 'J'),
+            ("SCHEMA_URI", "urn:ietf:params:scim:schemas:core:2.0:User"),
+            ("ATTRNAME", "userName"),
+            ("SW", "sw"),
+            ("COMP_VALUE", "J"),
         ]
         self.assertTokens(query, expected)
 
     def test_title_has_value(self):
-        query = 'title pr'
-        expected = [
-            ('ATTRNAME', 'title'),
-            ('PR', 'pr')
-        ]
+        query = "title pr"
+        expected = [("ATTRNAME", "title"), ("PR", "pr")]
         self.assertTokens(query, expected)
 
     def test_meta_last_modified_gt(self):
         query = 'meta.lastModified gt "2011-05-13T04:42:34Z"'
         expected = [
-            ('ATTRNAME', 'meta'),
-            ('SUBATTR', 'lastModified'),
-            ('GT', 'gt'),
-            ('COMP_VALUE', '2011-05-13T04:42:34Z'),
+            ("ATTRNAME", "meta"),
+            ("SUBATTR", "lastModified"),
+            ("GT", "gt"),
+            ("COMP_VALUE", "2011-05-13T04:42:34Z"),
         ]
         self.assertTokens(query, expected)
 
     def test_meta_last_modified_ge(self):
         query = 'meta.lastModified ge "2011-05-13T04:42:34Z"'
         expected = [
-            ('ATTRNAME', 'meta'),
-            ('SUBATTR', 'lastModified'),
-            ('GE', 'ge'),
-            ('COMP_VALUE', '2011-05-13T04:42:34Z'),
+            ("ATTRNAME", "meta"),
+            ("SUBATTR", "lastModified"),
+            ("GE", "ge"),
+            ("COMP_VALUE", "2011-05-13T04:42:34Z"),
         ]
         self.assertTokens(query, expected)
 
     def test_meta_last_modified_lt(self):
         query = 'meta.lastModified lt "2011-05-13T04:42:34Z"'
         expected = [
-            ('ATTRNAME', 'meta'),
-            ('SUBATTR', 'lastModified'),
-            ('LT', 'lt'),
-            ('COMP_VALUE', '2011-05-13T04:42:34Z'),
+            ("ATTRNAME", "meta"),
+            ("SUBATTR", "lastModified"),
+            ("LT", "lt"),
+            ("COMP_VALUE", "2011-05-13T04:42:34Z"),
         ]
         self.assertTokens(query, expected)
 
     def test_meta_last_modified_le(self):
         query = 'meta.lastModified le "2011-05-13T04:42:34Z"'
         expected = [
-            ('ATTRNAME', 'meta'),
-            ('SUBATTR', 'lastModified'),
-            ('LE', 'le'),
-            ('COMP_VALUE', '2011-05-13T04:42:34Z'),
+            ("ATTRNAME", "meta"),
+            ("SUBATTR", "lastModified"),
+            ("LE", "le"),
+            ("COMP_VALUE", "2011-05-13T04:42:34Z"),
         ]
         self.assertTokens(query, expected)
 
     def test_title_has_value_and_user_type_eq(self):
         query = 'title pr and userType eq "Employee"'
         expected = [
-            ('ATTRNAME', 'title'),
-            ('PR', 'pr'),
-            ('AND', 'and'),
-            ('ATTRNAME', 'userType'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'Employee')
+            ("ATTRNAME", "title"),
+            ("PR", "pr"),
+            ("AND", "and"),
+            ("ATTRNAME", "userType"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "Employee"),
         ]
         self.assertTokens(query, expected)
 
     def test_title_has_value_or_user_type_eq(self):
         query = 'title pr or userType eq "Intern"'
         expected = [
-            ('ATTRNAME', 'title'),
-            ('PR', 'pr'),
-            ('OR', 'or'),
-            ('ATTRNAME', 'userType'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'Intern')
+            ("ATTRNAME", "title"),
+            ("PR", "pr"),
+            ("OR", "or"),
+            ("ATTRNAME", "userType"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "Intern"),
         ]
         self.assertTokens(query, expected)
 
     def test_schemas_eq(self):
-        query = 'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        query = (
+            'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        )
         expected = [
-            ('ATTRNAME', 'schemas'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User')
+            ("ATTRNAME", "schemas"),
+            ("EQ", "eq"),
+            (
+                "COMP_VALUE",
+                "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+            ),
         ]
         self.assertTokens(query, expected)
 
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         query = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         expected = [
-            ('ATTRNAME', 'userType'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'Employee'),
-            ('AND', 'and'),
-            ('LPAREN', '('),
-            ('ATTRNAME', 'emails'),
-            ('CO', 'co'),
-            ('COMP_VALUE', 'example.com'),
-            ('OR', 'or'),
-            ('ATTRNAME', 'emails'),
-            ('SUBATTR', 'value'),
-            ('CO', 'co'),
-            ('COMP_VALUE', 'example.org'),
-            ('RPAREN', ')')
+            ("ATTRNAME", "userType"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "Employee"),
+            ("AND", "and"),
+            ("LPAREN", "("),
+            ("ATTRNAME", "emails"),
+            ("CO", "co"),
+            ("COMP_VALUE", "example.com"),
+            ("OR", "or"),
+            ("ATTRNAME", "emails"),
+            ("SUBATTR", "value"),
+            ("CO", "co"),
+            ("COMP_VALUE", "example.org"),
+            ("RPAREN", ")"),
         ]
         self.assertTokens(query, expected)
 
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         query = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
         expected = [
-            ('ATTRNAME', 'userType'),
-            ('NE', 'ne'),
-            ('COMP_VALUE', 'Employee'),
-            ('AND', 'and'),
-            ('NOT', 'not'),
-            ('LPAREN', '('),
-            ('ATTRNAME', 'emails'),
-            ('CO', 'co'),
-            ('COMP_VALUE', 'example.com'),
-            ('OR', 'or'),
-            ('ATTRNAME', 'emails'),
-            ('SUBATTR', 'value'),
-            ('CO', 'co'),
-            ('COMP_VALUE', 'example.org'),
-            ('RPAREN', ')')
+            ("ATTRNAME", "userType"),
+            ("NE", "ne"),
+            ("COMP_VALUE", "Employee"),
+            ("AND", "and"),
+            ("NOT", "not"),
+            ("LPAREN", "("),
+            ("ATTRNAME", "emails"),
+            ("CO", "co"),
+            ("COMP_VALUE", "example.com"),
+            ("OR", "or"),
+            ("ATTRNAME", "emails"),
+            ("SUBATTR", "value"),
+            ("CO", "co"),
+            ("COMP_VALUE", "example.org"),
+            ("RPAREN", ")"),
         ]
         self.assertTokens(query, expected)
 
     def test_user_type_eq_and_not_email_type_eq(self):
         query = 'userType eq "Employee" and (emails.type eq "work")'
         expected = [
-            ('ATTRNAME', 'userType'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'Employee'),
-            ('AND', 'and'),
-            ('LPAREN', '('),
-            ('ATTRNAME', 'emails'),
-            ('SUBATTR', 'type'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'work'),
-            ('RPAREN', ')')
+            ("ATTRNAME", "userType"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "Employee"),
+            ("AND", "and"),
+            ("LPAREN", "("),
+            ("ATTRNAME", "emails"),
+            ("SUBATTR", "type"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "work"),
+            ("RPAREN", ")"),
         ]
         self.assertTokens(query, expected)
 
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         expected = [
-            ('ATTRNAME', 'userType'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'Employee'),
-            ('AND', 'and'),
-            ('ATTRNAME', 'emails'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', 'type'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'work'),
-            ('AND', 'and'),
-            ('ATTRNAME', 'value'),
-            ('CO', 'co'),
-            ('COMP_VALUE', '@example.com'),
-            ('RBRACKET', ']')
+            ("ATTRNAME", "userType"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "Employee"),
+            ("AND", "and"),
+            ("ATTRNAME", "emails"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "type"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "work"),
+            ("AND", "and"),
+            ("ATTRNAME", "value"),
+            ("CO", "co"),
+            ("COMP_VALUE", "@example.com"),
+            ("RBRACKET", "]"),
         ]
         self.assertTokens(query, expected)
 
     def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         expected = [
-            ('ATTRNAME', 'emails'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', 'type'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'work'),
-            ('AND', 'and'),
-            ('ATTRNAME', 'value'),
-            ('CO', 'co'),
-            ('COMP_VALUE', '@example.com'),
-            ('RBRACKET', ']'),
-            ('OR', 'or'),
-            ('ATTRNAME', 'ims'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', 'type'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'xmpp'),
-            ('AND', 'and'),
-            ('ATTRNAME', 'value'),
-            ('CO', 'co'),
-            ('COMP_VALUE', '@foo.com'),
-            ('RBRACKET', ']')
+            ("ATTRNAME", "emails"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "type"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "work"),
+            ("AND", "and"),
+            ("ATTRNAME", "value"),
+            ("CO", "co"),
+            ("COMP_VALUE", "@example.com"),
+            ("RBRACKET", "]"),
+            ("OR", "or"),
+            ("ATTRNAME", "ims"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "type"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "xmpp"),
+            ("AND", "and"),
+            ("ATTRNAME", "value"),
+            ("CO", "co"),
+            ("COMP_VALUE", "@foo.com"),
+            ("RBRACKET", "]"),
         ]
         self.assertTokens(query, expected)
 
     def test_attribute_name_with_dollar_char(self):
         query = 'manager.$ref eq "/v2/Users/a"'
         expected = [
-            ('ATTRNAME', 'manager'),
-            ('SUBATTR', '$ref'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '/v2/Users/a')
+            ("ATTRNAME", "manager"),
+            ("SUBATTR", "$ref"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "/v2/Users/a"),
         ]
         self.assertTokens(query, expected)
 
     def test_attribute_name_with_dollar_char_complex_query(self):
         query = 'manager[$ref eq "/v2/Users/q" and value eq "q"] or userName eq "tom"'
         expected = [
-            ('ATTRNAME', 'manager'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', '$ref'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '/v2/Users/q'),
-            ('AND', 'and'),
-            ('ATTRNAME', 'value'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'q'),
-            ('RBRACKET', ']'),
-            ('OR', 'or'),
-            ('ATTRNAME', 'userName'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'tom')
+            ("ATTRNAME", "manager"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "$ref"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "/v2/Users/q"),
+            ("AND", "and"),
+            ("ATTRNAME", "value"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "q"),
+            ("RBRACKET", "]"),
+            ("OR", "or"),
+            ("ATTRNAME", "userName"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "tom"),
         ]
         self.assertTokens(query, expected)
 
@@ -289,29 +293,29 @@ class RegressionTestQueries(TestCase):
     def test_co_after_dot_not_considered_CO_token(self):
         query = 'addresses[type eq "work"].country eq ""'
         expected = [
-            ('ATTRNAME', 'addresses'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', 'type'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'work'),
-            ('RBRACKET', ']'),
-            ('SUBATTR', 'country'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '')
+            ("ATTRNAME", "addresses"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "type"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "work"),
+            ("RBRACKET", "]"),
+            ("SUBATTR", "country"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", ""),
         ]
         self.assertTokens(query, expected)
 
     def test_members(self):
         query = 'members[value eq "6784"] eq ""'
         expected = [
-            ('ATTRNAME', 'members'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', 'value'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '6784'),
-            ('RBRACKET', ']'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '')
+            ("ATTRNAME", "members"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "value"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "6784"),
+            ("RBRACKET", "]"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", ""),
         ]
         self.assertTokens(query, expected)
 
@@ -332,34 +336,49 @@ class TokenNotMistakenAsOperatorTestQueries(TestCase):
     def test_pr_in_preferred_not_considered_pr_token(self):
         query = 'preferredLanguage eq ""'
         expected = [
-            ('ATTRNAME', 'preferredLanguage'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', ''),
+            ("ATTRNAME", "preferredLanguage"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", ""),
         ]
         self.assertTokens(query, expected)
 
     def test_cap_pr_token(self):
-        query = 'lang Pr'
+        query = "lang Pr"
         expected = [
-            ('ATTRNAME', 'lang'),
-            ('PR', 'Pr'),
+            ("ATTRNAME", "lang"),
+            ("PR", "Pr"),
         ]
         self.assertTokens(query, expected)
 
     def test_token_startswith_op_code(self):
         op_codes = {
-            'eg', 'ne', 'co', 'sw', 'ew', 'pr', 'gt', 'ge', 'lt', 'le',
-            'and', 'or', 'not'
+            "eg",
+            "ne",
+            "co",
+            "sw",
+            "ew",
+            "pr",
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "and",
+            "or",
+            "not",
         }
         for op_code in op_codes:
             for permuation in self.get_op_permutation(op_code):
-                attrname = permuation + 'ing'  # Add any suffix to make token an attrname
-                attr_token, eq_token, comp_token = self.get_token_tuples(attrname + ' eq ""')
+                attrname = (
+                    permuation + "ing"
+                )  # Add any suffix to make token an attrname
+                attr_token, eq_token, comp_token = self.get_token_tuples(
+                    attrname + ' eq ""'
+                )
 
-                self.assertEqual(attr_token.type, 'ATTRNAME')
+                self.assertEqual(attr_token.type, "ATTRNAME")
                 self.assertEqual(attr_token.value, attrname)
-                self.assertEqual(eq_token.type, 'EQ')
-                self.assertEqual(comp_token.type, 'COMP_VALUE')
+                self.assertEqual(eq_token.type, "EQ")
+                self.assertEqual(comp_token.type, "COMP_VALUE")
 
     def get_op_permutation(self, op_code):
         """
@@ -368,11 +387,11 @@ class TokenNotMistakenAsOperatorTestQueries(TestCase):
         permuations = []
         for i in range(2 ** len(op_code)):
             # use bits as indices to capitalize
-            mask = str(bin(i)).replace('0b', '').zfill(len(op_code))
+            mask = str(bin(i)).replace("0b", "").zfill(len(op_code))
 
-            permuation = ''
+            permuation = ""
             for j, char in enumerate(op_code):
-                if mask[j:j+1] == '1':
+                if mask[j : j + 1] == "1":
                     permuation += char.upper()
                 else:
                     permuation += char.lower()
@@ -396,36 +415,38 @@ class AzureQueries(TestCase):
         self.assertEqual(expected, token_tuples)
 
     def test_email_type_eq_primary_value_eq_uuid(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         expected = [
-            ('ATTRNAME', 'emails'),
-            ('LBRACKET', '['),
-            ('ATTRNAME', 'type'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', 'Primary'),
-            ('RBRACKET', ']'),
-            ('SUBATTR', 'value'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '001750ca-8202-47cd-b553-c63f4f245940')
+            ("ATTRNAME", "emails"),
+            ("LBRACKET", "["),
+            ("ATTRNAME", "type"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "Primary"),
+            ("RBRACKET", "]"),
+            ("SUBATTR", "value"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "001750ca-8202-47cd-b553-c63f4f245940"),
         ]
         self.assertTokens(query, expected)
 
     def test_external_id_from_azure(self):
         query = 'externalId eq "4d32ab19-ae09-4236-82fa-15768bc48a08"'
         expected = [
-            ('ATTRNAME', 'externalId'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '4d32ab19-ae09-4236-82fa-15768bc48a08')
+            ("ATTRNAME", "externalId"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "4d32ab19-ae09-4236-82fa-15768bc48a08"),
         ]
         self.assertTokens(query, expected)
 
     def test_parse_simple_email_filter_with_uuid(self):
         query = 'emails.value eq "001750ca-8202-47cd-b553-c63f4f245940"'
         expected = [
-            ('ATTRNAME', 'emails'),
-            ('SUBATTR', 'value'),
-            ('EQ', 'eq'),
-            ('COMP_VALUE', '001750ca-8202-47cd-b553-c63f4f245940')
+            ("ATTRNAME", "emails"),
+            ("SUBATTR", "value"),
+            ("EQ", "eq"),
+            ("COMP_VALUE", "001750ca-8202-47cd-b553-c63f4f245940"),
         ]
         self.assertTokens(query, expected)
 
@@ -440,11 +461,10 @@ class CommandLine(TestCase):
 
     def test_command_line(self):
         lexer.main(['userName eq "bjensen"'])
-        result = self.test_stdout.getvalue().strip().split('\n')
+        result = self.test_stdout.getvalue().strip().split("\n")
         expected = [
             "Token(type='ATTRNAME', value='userName', lineno=1, index=0, end=8)",
             "Token(type='EQ', value='eq', lineno=1, index=9, end=11)",
             "Token(type='COMP_VALUE', value='bjensen', lineno=1, index=12, end=21)",
         ]
         self.assertEqual(result, expected)
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,7 +17,7 @@ class RegressionTestQueries(TestCase):
 
     def test_command_line(self):
         parser.main(['members[value eq "6784"] eq ""'])
-        result = self.test_stdout.getvalue().strip().split('\n')
+        result = self.test_stdout.getvalue().strip().split("\n")
         expected = [
             "Filter(expr=AttrExpr, negated=False, namespace=None)",
             "     AttrExpr(value='eq', attr_path=AttrPath, comp_value=CompValue)",
@@ -39,7 +39,7 @@ class BuggyQueries(TestCase):
         self.parser = parser.SCIMParser()
 
     def test_no_quotes_around_comp_value(self):
-        query = 'userName eq example@example.com'
+        query = "userName eq example@example.com"
 
         token_stream = self.lexer.tokenize(query)
 
@@ -75,11 +75,11 @@ class CommandLine(TestCase):
 
     def test_command_line(self):
         parser.main(['userName eq "bjensen"'])
-        result = self.test_stdout.getvalue().strip().split('\n')
+        result = self.test_stdout.getvalue().strip().split("\n")
         expected = [
-            'Filter(expr=AttrExpr, negated=False, namespace=None)',
+            "Filter(expr=AttrExpr, negated=False, namespace=None)",
             "     AttrExpr(value='eq', attr_path=AttrPath, comp_value=CompValue)",
             "         AttrPath(attr_name='userName', sub_attr=None, uri=None)",
-            "         CompValue(value='bjensen')"
+            "         CompValue(value='bjensen')",
         ]
         self.assertEqual(result, expected)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -9,7 +9,7 @@ import scim2_filter_parser.queries.sql as queries_sql
 class RFCExamples(unittest.TestCase):
     maxDiff = None
 
-    CREATE_TABLE_USERS = '''
+    CREATE_TABLE_USERS = """
     CREATE TABLE users
     (
         id INTEGER PRIMARY KEY,
@@ -21,9 +21,9 @@ class RFCExamples(unittest.TestCase):
         update_ts DATETIME,
         user_type TEXT
     )
-    '''
+    """
 
-    INSERT_USERS = '''
+    INSERT_USERS = """
     INSERT INTO users
         (id, username, first_name, last_name, nickname, title, update_ts, user_type)
     VALUES
@@ -36,9 +36,9 @@ class RFCExamples(unittest.TestCase):
         (6, 'ge', 'Greg', 'Edgar', NULL, NULL, '2011-05-13T04:42:34Z', NULL),
         (7, 'lt', 'Lisa', 'Ting', NULL, NULL, '2010-05-13T04:42:34Z', NULL),
         (8, 'le', 'Linda', 'Euler', NULL, NULL, '2011-05-13T04:42:34Z', NULL)
-    '''
+    """
 
-    CREATE_TABLE_EMAILS = '''
+    CREATE_TABLE_EMAILS = """
     CREATE TABLE emails
     (
         id INTEGER PRIMARY KEY,
@@ -47,17 +47,17 @@ class RFCExamples(unittest.TestCase):
         type TYPE,
         FOREIGN KEY(user_id) REFERENCES users(id)
     )
-    '''
+    """
 
-    INSERT_EMAILS = '''
+    INSERT_EMAILS = """
     INSERT INTO emails
         (id, user_id, text, type)
     VALUES
         (1, 3, 'jacob@example.com', 'work'),
         (2, 4, 'carly@example.net', 'home')
-    '''
+    """
 
-    CREATE_TABLE_IMS = '''
+    CREATE_TABLE_IMS = """
     CREATE TABLE ims
     (
         id INTEGER PRIMARY KEY,
@@ -66,16 +66,16 @@ class RFCExamples(unittest.TestCase):
         type TYPE,
         FOREIGN KEY(user_id) REFERENCES users(id)
     )
-    '''
+    """
 
-    INSERT_IMS = '''
+    INSERT_IMS = """
     INSERT INTO ims
         (id, user_id, text, type)
     VALUES
         (1, 1, 'brie@foo.com', 'xmpp')
-    '''
+    """
 
-    CREATE_TABLE_SCHEMAS = '''
+    CREATE_TABLE_SCHEMAS = """
     CREATE TABLE schemas
     (
         id INTEGER PRIMARY KEY,
@@ -83,41 +83,41 @@ class RFCExamples(unittest.TestCase):
         text TEXT,
         FOREIGN KEY(user_id) REFERENCES users(id)
     )
-    '''
+    """
 
-    INSERT_SCHEMAS = '''
+    INSERT_SCHEMAS = """
     INSERT INTO schemas
         (id, user_id, text)
     VALUES
         (1, 4, 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User')
-    '''
+    """
 
     ATTR_MAP = {
         # attr_name, sub_attr, uri: table name
-        ('title', None, None): 'users.title',
-        ('userName', None, None): 'users.username',
-        ('nickName', None, None): 'users.nickname',
-        ('userType', None, None): 'users.user_type',
-        ('name', 'familyName', None): 'users.last_name',
-        ('meta', 'lastModified', None): 'users.update_ts',
-        ('emails', None, None): 'emails.text',
-        ('emails', 'value', None): 'emails.text',
-        ('emails', 'type', None): 'emails.type',
-        ('ims', 'value', None): 'ims.text',
-        ('ims', 'type', None): 'ims.type',
-        ('schemas', None, None): 'schemas.text',
-        ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'username',
-        ('nickName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'nickname',
+        ("title", None, None): "users.title",
+        ("userName", None, None): "users.username",
+        ("nickName", None, None): "users.nickname",
+        ("userType", None, None): "users.user_type",
+        ("name", "familyName", None): "users.last_name",
+        ("meta", "lastModified", None): "users.update_ts",
+        ("emails", None, None): "emails.text",
+        ("emails", "value", None): "emails.text",
+        ("emails", "type", None): "emails.type",
+        ("ims", "value", None): "ims.text",
+        ("ims", "type", None): "ims.type",
+        ("schemas", None, None): "schemas.text",
+        ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "username",
+        ("nickName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "nickname",
     }
 
     JOINS = (
-        'LEFT JOIN emails ON emails.user_id = users.id',
-        'LEFT JOIN ims ON ims.user_id = users.id',
-        'LEFT JOIN schemas ON schemas.user_id = users.id',
+        "LEFT JOIN emails ON emails.user_id = users.id",
+        "LEFT JOIN ims ON ims.user_id = users.id",
+        "LEFT JOIN schemas ON schemas.user_id = users.id",
     )
 
     def setUp(self):
-        self.conn = sqlite3.connect(':memory:')
+        self.conn = sqlite3.connect(":memory:")
         self.cursor = self.conn.cursor()
         self.cursor.execute(self.CREATE_TABLE_USERS)
         self.cursor.execute(self.INSERT_USERS)
@@ -130,7 +130,7 @@ class RFCExamples(unittest.TestCase):
         self.conn.commit()
 
     def assertRows(self, query, expected_rows):
-        q = queries_sql.SQLiteQuery(query, 'users', self.ATTR_MAP, self.JOINS)
+        q = queries_sql.SQLiteQuery(query, "users", self.ATTR_MAP, self.JOINS)
         self.cursor.execute(q.sql, q.params)
         results = self.cursor.fetchall()
 
@@ -138,127 +138,129 @@ class RFCExamples(unittest.TestCase):
 
     def test_nickname_eq(self):
         query = 'nickName eq "BB"'
-        expected_rows = [
-            (1, 'bjensen', 'Brie', 'Jensen', 'BB', None, None, None)
-        ]
+        expected_rows = [(1, "bjensen", "Brie", "Jensen", "BB", None, None, None)]
         self.assertRows(query, expected_rows)
 
     def test_family_name_contains(self):
         query = '''name.familyName co "O'Malley"'''
         expected_rows = [
-            (2, 'momalley', 'Mike', "O'Malley", None, None, None, None),
+            (2, "momalley", "Mike", "O'Malley", None, None, None, None),
         ]
         self.assertRows(query, expected_rows)
 
     def test_nickname_startswith(self):
         query = 'nickName sw "J"'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_schema_username_startswith(self):
         query = 'urn:ietf:params:scim:schemas:core:2.0:User:nickName sw "J"'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_title_has_value(self):
-        query = 'title pr'
+        query = "title pr"
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_meta_last_modified_gt(self):
         query = 'meta.lastModified gt "2011-05-13T04:42:34Z"'
         expected_rows = [
-            (5, 'gt', 'Gina', 'Taylor', None, None, '2012-05-13T04:42:34Z', None),
+            (5, "gt", "Gina", "Taylor", None, None, "2012-05-13T04:42:34Z", None),
         ]
         self.assertRows(query, expected_rows)
 
     def test_meta_last_modified_ge(self):
         query = 'meta.lastModified ge "2011-05-13T04:42:34Z"'
         expected_rows = [
-            (5, 'gt', 'Gina', 'Taylor', None, None, '2012-05-13T04:42:34Z', None),
-            (6, 'ge', 'Greg', 'Edgar', None, None, '2011-05-13T04:42:34Z', None),
-            (8, 'le', 'Linda', 'Euler', None, None, '2011-05-13T04:42:34Z', None)
+            (5, "gt", "Gina", "Taylor", None, None, "2012-05-13T04:42:34Z", None),
+            (6, "ge", "Greg", "Edgar", None, None, "2011-05-13T04:42:34Z", None),
+            (8, "le", "Linda", "Euler", None, None, "2011-05-13T04:42:34Z", None),
         ]
         self.assertRows(query, expected_rows)
 
     def test_meta_last_modified_lt(self):
         query = 'meta.lastModified lt "2011-05-13T04:42:34Z"'
         expected_rows = [
-            (7, 'lt', 'Lisa', 'Ting', None, None, '2010-05-13T04:42:34Z', None),
+            (7, "lt", "Lisa", "Ting", None, None, "2010-05-13T04:42:34Z", None),
         ]
         self.assertRows(query, expected_rows)
 
     def test_meta_last_modified_le(self):
         query = 'meta.lastModified le "2011-05-13T04:42:34Z"'
         expected_rows = [
-            (6, 'ge', 'Greg', 'Edgar', None, None, '2011-05-13T04:42:34Z', None),
-            (7, 'lt', 'Lisa', 'Ting', None, None, '2010-05-13T04:42:34Z', None),
-            (8, 'le', 'Linda', 'Euler', None, None, '2011-05-13T04:42:34Z', None)
+            (6, "ge", "Greg", "Edgar", None, None, "2011-05-13T04:42:34Z", None),
+            (7, "lt", "Lisa", "Ting", None, None, "2010-05-13T04:42:34Z", None),
+            (8, "le", "Linda", "Euler", None, None, "2011-05-13T04:42:34Z", None),
         ]
         self.assertRows(query, expected_rows)
 
     def test_title_has_value_and_user_type_eq(self):
         query = 'title pr and userType eq "Employee"'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_title_has_value_or_user_type_eq(self):
         query = 'title pr or userType eq "Intern"'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
-            (4, 'crobertson', 'Carly', 'Robertson', None, None, None, 'Intern'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
+            (4, "crobertson", "Carly", "Robertson", None, None, None, "Intern"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_schemas_eq(self):
-        query = 'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        query = (
+            'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        )
         expected_rows = [
-            (4, 'crobertson', 'Carly', 'Robertson', None, None, None, 'Intern'),
+            (4, "crobertson", "Carly", "Robertson", None, None, None, "Intern"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         query = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         query = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
         expected_rows = [
-            (4, 'crobertson', 'Carly', 'Robertson', None, None, None, 'Intern'),
+            (4, "crobertson", "Carly", "Robertson", None, None, None, "Intern"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_user_type_eq_and_not_email_type_eq(self):
         query = 'userType eq "Employee" and (emails.type eq "work")'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         expected_rows = [
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
     def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         expected_rows = [
-            (1, 'bjensen', 'Brie', 'Jensen', 'BB', None, None, None),
-            (3, 'Jacob', 'Jacob', 'Jingleheimer', 'JJ', 'Friend', None, 'Employee'),
+            (1, "bjensen", "Brie", "Jensen", "BB", None, None, None),
+            (3, "Jacob", "Jacob", "Jingleheimer", "JJ", "Friend", None, "Employee"),
         ]
         self.assertRows(query, expected_rows)
 
@@ -266,24 +268,24 @@ class RFCExamples(unittest.TestCase):
 class AzureQueries(unittest.TestCase):
     maxDiff = None
 
-    CREATE_TABLE_USERS = '''
+    CREATE_TABLE_USERS = """
     CREATE TABLE users
     (
         id INTEGER PRIMARY KEY,
         external_id TEXT
     )
-    '''
+    """
 
-    INSERT_USERS = '''
+    INSERT_USERS = """
     INSERT INTO users
         (id, external_id)
     VALUES
         (1, '4d32ab19-ae09-4236-82fa-15768bc48a08'),
         (2, '5ef40940-ae09-4236-82fa-ab184843992c'),
         (3, '83901010-ae09-4236-82fa-576381818313')
-    '''
+    """
 
-    CREATE_TABLE_EMAILS = '''
+    CREATE_TABLE_EMAILS = """
     CREATE TABLE emails
     (
         id INTEGER PRIMARY KEY,
@@ -292,9 +294,9 @@ class AzureQueries(unittest.TestCase):
         type TYPE,
         FOREIGN KEY(user_id) REFERENCES users(id)
     )
-    '''
+    """
 
-    INSERT_EMAILS = '''
+    INSERT_EMAILS = """
     INSERT INTO emails
         (id, user_id, text, type)
     VALUES
@@ -302,22 +304,20 @@ class AzureQueries(unittest.TestCase):
         (2, 1, 'carly@example.net', 'home'),
         (3, 2, 'james@example.net', 'home'),
         (4, 3, '9438932a-8202-47cd-b553-85afc2939193', 'Primary')
-    '''
+    """
 
     ATTR_MAP = {
         # attr_name, sub_attr, uri: table name
-        ('externalId', None, None): 'users.external_id',
-        ('emails', None, None): 'emails.text',
-        ('emails', 'value', None): 'emails.text',
-        ('emails', 'type', None): 'emails.type',
+        ("externalId", None, None): "users.external_id",
+        ("emails", None, None): "emails.text",
+        ("emails", "value", None): "emails.text",
+        ("emails", "type", None): "emails.type",
     }
 
-    JOINS = (
-        'LEFT JOIN emails ON emails.user_id = users.id',
-    )
+    JOINS = ("LEFT JOIN emails ON emails.user_id = users.id",)
 
     def setUp(self):
-        self.conn = sqlite3.connect(':memory:')
+        self.conn = sqlite3.connect(":memory:")
         self.cursor = self.conn.cursor()
         self.cursor.execute(self.CREATE_TABLE_USERS)
         self.cursor.execute(self.INSERT_USERS)
@@ -326,54 +326,50 @@ class AzureQueries(unittest.TestCase):
         self.conn.commit()
 
     def assertRows(self, query, expected_rows):
-        q = queries_sql.SQLiteQuery(query, 'users', self.ATTR_MAP, self.JOINS)
+        q = queries_sql.SQLiteQuery(query, "users", self.ATTR_MAP, self.JOINS)
         self.cursor.execute(q.sql, q.params)
         results = self.cursor.fetchall()
         self.assertEqual(expected_rows, results)
 
     def test_email_type_eq_primary_value_eq_uuid(self):
-        query = 'emails[type eq "Primary"].value eq "9438932a-8202-47cd-b553-85afc2939193"'
-        expected_rows = [
-            (3, '83901010-ae09-4236-82fa-576381818313')
-        ]
+        query = (
+            'emails[type eq "Primary"].value eq "9438932a-8202-47cd-b553-85afc2939193"'
+        )
+        expected_rows = [(3, "83901010-ae09-4236-82fa-576381818313")]
         self.assertRows(query, expected_rows)
 
     def test_external_id_from_azure(self):
         query = 'externalId eq "5ef40940-ae09-4236-82fa-ab184843992c"'
-        expected_rows = [
-            (2, '5ef40940-ae09-4236-82fa-ab184843992c')
-        ]
+        expected_rows = [(2, "5ef40940-ae09-4236-82fa-ab184843992c")]
         self.assertRows(query, expected_rows)
 
     def test_parse_simple_email_filter_with_uuid(self):
         query = 'emails.value eq "001750ca-8202-47cd-b553-c63f4f245940"'
-        expected_rows = [
-            (1, '4d32ab19-ae09-4236-82fa-15768bc48a08')
-        ]
+        expected_rows = [(1, "4d32ab19-ae09-4236-82fa-15768bc48a08")]
         self.assertRows(query, expected_rows)
 
 
 class GeneralQueries(unittest.TestCase):
     maxDiff = None
 
-    CREATE_TABLE_USERS = '''
+    CREATE_TABLE_USERS = """
     CREATE TABLE users
     (
         id INTEGER PRIMARY KEY,
         name TEXT
     )
-    '''
+    """
 
-    INSERT_USERS = '''
+    INSERT_USERS = """
     INSERT INTO users
         (id, name)
     VALUES
         (1, 'Paul'),
         (2, 'Chris'),
         (3, 'Eileen')
-    '''
+    """
 
-    CREATE_TABLE_EMAILS = '''
+    CREATE_TABLE_EMAILS = """
     CREATE TABLE emails
     (
         id INTEGER PRIMARY KEY,
@@ -382,27 +378,25 @@ class GeneralQueries(unittest.TestCase):
         type TYPE,
         FOREIGN KEY(user_id) REFERENCES users(id)
     )
-    '''
+    """
 
-    INSERT_EMAILS = '''
+    INSERT_EMAILS = """
     INSERT INTO emails
         (id, user_id, text, type)
     VALUES
         (1, 1, 'paul@example.net', 'home'),
         (2, 1, 'paul@example.net', 'work')
-    '''
+    """
 
     ATTR_MAP = {
         # attr_name, sub_attr, uri: table name
-        ('emails', 'value', None): 'emails.text',
+        ("emails", "value", None): "emails.text",
     }
 
-    JOINS = (
-        'LEFT JOIN emails ON emails.user_id = users.id',
-    )
+    JOINS = ("LEFT JOIN emails ON emails.user_id = users.id",)
 
     def setUp(self):
-        self.conn = sqlite3.connect(':memory:')
+        self.conn = sqlite3.connect(":memory:")
         self.cursor = self.conn.cursor()
         self.cursor.execute(self.CREATE_TABLE_USERS)
         self.cursor.execute(self.INSERT_USERS)
@@ -411,16 +405,14 @@ class GeneralQueries(unittest.TestCase):
         self.conn.commit()
 
     def assertRows(self, query, expected_rows):
-        q = queries_sql.SQLiteQuery(query, 'users', self.ATTR_MAP, self.JOINS)
+        q = queries_sql.SQLiteQuery(query, "users", self.ATTR_MAP, self.JOINS)
         self.cursor.execute(q.sql, q.params)
         results = self.cursor.fetchall()
         self.assertEqual(expected_rows, results)
 
     def test_ensure_distinct_rows_fetched(self):
         query = 'emails.value eq "paul@example.net"'
-        expected_rows = [
-            (1, 'Paul')
-        ]
+        expected_rows = [(1, "Paul")]
         self.assertRows(query, expected_rows)
 
 
@@ -434,17 +426,16 @@ class CommandLine(unittest.TestCase):
 
     def test_command_line(self):
         queries_sql.main(['userName eq "bjensen"'])
-        result = self.test_stdout.getvalue().strip().split('\n')
+        result = self.test_stdout.getvalue().strip().split("\n")
 
         expected = [
-            '>>> DO NOT USE THIS OUTPUT DIRECTLY',
-            '>>> SQL INJECTION ATTACK RISK',
-            '>>> SQL PREVIEW:',
-            '    SELECT DISTINCT users.*',
-            '    FROM users',
-            '    LEFT JOIN emails ON emails.user_id = users.id',
-            '    LEFT JOIN schemas ON schemas.user_id = users.id',
-            '    WHERE UPPER(username) = UPPER(bjensen);'
+            ">>> DO NOT USE THIS OUTPUT DIRECTLY",
+            ">>> SQL INJECTION ATTACK RISK",
+            ">>> SQL PREVIEW:",
+            "    SELECT DISTINCT users.*",
+            "    FROM users",
+            "    LEFT JOIN emails ON emails.user_id = users.id",
+            "    LEFT JOIN schemas ON schemas.user_id = users.id",
+            "    WHERE UPPER(username) = UPPER(bjensen);",
         ]
         self.assertEqual(result, expected)
-

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -31,20 +31,20 @@ class SetupHelper(TestCase):
 
 class RFCExamples(SetupHelper, TestCase):
     attr_map = {
-        ('name', 'familyName', None): 'name.familyname',
-        ('emails', None, None): 'emails',
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('userName', None, None): 'username',
-        ('nickName', None, None): 'nickname',
-        ('title', None, None): 'title',
-        ('userType', None, None): 'usertype',
-        ('schemas', None, None): 'schemas',
-        ('userName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'username',
-        ('nickName', None, 'urn:ietf:params:scim:schemas:core:2.0:User'): 'nickname',
-        ('meta', 'lastModified', None): 'meta.lastmodified',
-        ('ims', 'type', None): 'ims.type',
-        ('ims', 'value', None): 'ims.value',
+        ("name", "familyName", None): "name.familyname",
+        ("emails", None, None): "emails",
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("userName", None, None): "username",
+        ("nickName", None, None): "nickname",
+        ("title", None, None): "title",
+        ("userType", None, None): "usertype",
+        ("schemas", None, None): "schemas",
+        ("userName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "username",
+        ("nickName", None, "urn:ietf:params:scim:schemas:core:2.0:User"): "nickname",
+        ("meta", "lastModified", None): "meta.lastmodified",
+        ("ims", "type", None): "ims.type",
+        ("ims", "value", None): "ims.value",
     }
 
     def test_attr_paths_are_created(self):
@@ -64,122 +64,128 @@ class RFCExamples(SetupHelper, TestCase):
     def test_username_eq(self):
         query = 'userName eq "bjensen"'
         sql = "UPPER(username) = UPPER({a})"
-        params = {'a': 'bjensen'}
+        params = {"a": "bjensen"}
         self.assertSQL(query, sql, params)
 
     def test_nickname_eq(self):
         query = 'nickName eq "Bob"'
         sql = "nickname = {a}"
-        params = {'a': 'Bob'}
+        params = {"a": "Bob"}
         self.assertSQL(query, sql, params)
 
     def test_family_name_contains(self):
         query = '''name.familyName co "O'Malley"'''
         sql = "name.familyname LIKE {a}"
-        params = {'a': "%O'Malley%"}
+        params = {"a": "%O'Malley%"}
         self.assertSQL(query, sql, params)
 
     def test_username_startswith(self):
         query = 'userName sw "J"'
         sql = "UPPER(username) LIKE UPPER({a})"
-        params = {'a': 'J%'}
+        params = {"a": "J%"}
         self.assertSQL(query, sql, params)
 
     def test_nickname_startswith(self):
         query = 'nickName sw "J"'
         sql = "nickname LIKE {a}"
-        params = {'a': 'J%'}
+        params = {"a": "J%"}
         self.assertSQL(query, sql, params)
 
     def test_schema_username_startswith(self):
         query = 'urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"'
         sql = "UPPER(username) LIKE UPPER({a})"
-        params = {'a': 'J%'}
+        params = {"a": "J%"}
         self.assertSQL(query, sql, params)
 
     def test_schema_nickname_startswith(self):
         query = 'urn:ietf:params:scim:schemas:core:2.0:User:nickName sw "J"'
         sql = "nickname LIKE {a}"
-        params = {'a': 'J%'}
+        params = {"a": "J%"}
         self.assertSQL(query, sql, params)
 
     def test_title_has_value(self):
-        query = 'title pr'
-        sql = 'title IS NOT NULL'
-        params = {'a': None}
+        query = "title pr"
+        sql = "title IS NOT NULL"
+        params = {"a": None}
         self.assertSQL(query, sql, params)
 
     def test_meta_last_modified_gt(self):
         query = 'meta.lastModified gt "2011-05-13T04:42:34Z"'
         sql = "meta.lastmodified > {a}"
-        params = {'a': '2011-05-13T04:42:34Z'}
+        params = {"a": "2011-05-13T04:42:34Z"}
         self.assertSQL(query, sql, params)
 
     def test_meta_last_modified_ge(self):
         query = 'meta.lastModified ge "2011-05-13T04:42:34Z"'
         sql = "meta.lastmodified >= {a}"
-        params = {'a': '2011-05-13T04:42:34Z'}
+        params = {"a": "2011-05-13T04:42:34Z"}
         self.assertSQL(query, sql, params)
 
     def test_meta_last_modified_lt(self):
         query = 'meta.lastModified lt "2011-05-13T04:42:34Z"'
         sql = "meta.lastmodified < {a}"
-        params = {'a': '2011-05-13T04:42:34Z'}
+        params = {"a": "2011-05-13T04:42:34Z"}
         self.assertSQL(query, sql, params)
 
     def test_meta_last_modified_le(self):
         query = 'meta.lastModified le "2011-05-13T04:42:34Z"'
         sql = "meta.lastmodified <= {a}"
-        params = {'a': '2011-05-13T04:42:34Z'}
+        params = {"a": "2011-05-13T04:42:34Z"}
         self.assertSQL(query, sql, params)
 
     def test_title_has_value_and_user_type_eq(self):
         query = 'title pr and userType eq "Employee"'
         sql = "(title IS NOT NULL) AND (usertype = {b})"
-        params = {'a': None, 'b': 'Employee'}
+        params = {"a": None, "b": "Employee"}
         self.assertSQL(query, sql, params)
 
     def test_title_has_value_or_user_type_eq(self):
         query = 'title pr or userType eq "Intern"'
         sql = "(title IS NOT NULL) OR (usertype = {b})"
-        params = {'a': None, 'b': 'Intern'}
+        params = {"a": None, "b": "Intern"}
         self.assertSQL(query, sql, params)
 
     def test_schemas_eq(self):
-        query = 'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        query = (
+            'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        )
         sql = "schemas = {a}"
-        params = {'a': "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"}
+        params = {"a": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"}
         self.assertSQL(query, sql, params)
 
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         query = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         sql = "(usertype = {a}) AND ((emails LIKE {b}) OR (emails.value LIKE {c}))"
-        params = {'a': 'Employee', 'b': '%example.com%', 'c': '%example.org%'}
+        params = {"a": "Employee", "b": "%example.com%", "c": "%example.org%"}
         self.assertSQL(query, sql, params)
 
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         query = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
-        sql = "(usertype != {a}) AND (NOT ((emails LIKE {b}) OR (emails.value LIKE {c})))"
-        params = {'a': 'Employee', 'b': '%example.com%', 'c': '%example.org%'}
+        sql = (
+            "(usertype != {a}) AND (NOT ((emails LIKE {b}) OR (emails.value LIKE {c})))"
+        )
+        params = {"a": "Employee", "b": "%example.com%", "c": "%example.org%"}
         self.assertSQL(query, sql, params)
 
     def test_user_type_eq_and_not_email_type_eq(self):
         query = 'userType eq "Employee" and (emails.type eq "work")'
         sql = "(usertype = {a}) AND (emails.type = {b})"
-        params = {'a': 'Employee', 'b': 'work'}
+        params = {"a": "Employee", "b": "work"}
         self.assertSQL(query, sql, params)
 
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         sql = "(usertype = {a}) AND ((emails.type = {b}) AND (emails.value LIKE {c}))"
-        params = {'a': 'Employee', 'b': 'work', 'c': '%@example.com%'}
+        params = {"a": "Employee", "b": "work", "c": "%@example.com%"}
         self.assertSQL(query, sql, params)
 
     def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         sql = "((emails.type = {a}) AND (emails.value LIKE {b})) OR ((ims.type = {c}) AND (ims.value LIKE {d}))"
-        params = {'a': 'work', 'b': '%@example.com%', 'c': 'xmpp', 'd': '%@foo.com%'}
+        params = {"a": "work", "b": "%@example.com%", "c": "xmpp", "d": "%@foo.com%"}
         self.assertSQL(query, sql, params)
 
     def test_username_with_more_complex_query(self):
@@ -189,22 +195,21 @@ class RFCExamples(SetupHelper, TestCase):
             'userName eq "bjensen"'
         )
         sql = (
-            '(((emails.type = {a}) AND (emails.value LIKE {b})) OR '
-            '((ims.type = {c}) AND (ims.value LIKE {d}))) OR '
-            '(UPPER(username) = UPPER({e}))'
+            "(((emails.type = {a}) AND (emails.value LIKE {b})) OR "
+            "((ims.type = {c}) AND (ims.value LIKE {d}))) OR "
+            "(UPPER(username) = UPPER({e}))"
         )
         params = {
-            'a': 'work',
-            'b': '%@example.com%',
-            'c': 'xmpp',
-            'd': '%@foo.com%',
-            'e': 'bjensen',
+            "a": "work",
+            "b": "%@example.com%",
+            "c": "xmpp",
+            "d": "%@foo.com%",
+            "e": "bjensen",
         }
         self.assertSQL(query, sql, params)
 
 
 class UndefinedAttributes(SetupHelper, TestCase):
-
     def test_username_eq(self):
         query = 'userName eq "bjensen"'
         sql = None
@@ -215,23 +220,25 @@ class UndefinedAttributes(SetupHelper, TestCase):
     def test_title_has_value_and_user_type_eq_1(self):
         query = 'title pr and userType eq "Employee"'
         sql = "title IS NOT NULL"
-        params = {'a': None}
+        params = {"a": None}
         attr_map = {
-            ('title', None, None): 'title',
+            ("title", None, None): "title",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_title_has_value_and_user_type_eq_2(self):
         query = 'title pr and userType eq "Employee"'
         sql = "usertype = {a}"
-        params = {'a': 'Employee'}
+        params = {"a": "Employee"}
         attr_map = {
-            ('userType', None, None): 'usertype',
+            ("userType", None, None): "usertype",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_schemas_eq(self):
-        query = 'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        query = (
+            'schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"'
+        )
         sql = None
         params = {}
         attr_map = {}
@@ -240,171 +247,195 @@ class UndefinedAttributes(SetupHelper, TestCase):
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         query = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         sql = "(usertype = {a}) AND ((emails LIKE {b}) OR (emails.value LIKE {c}))"
-        params = {'a': 'Employee', 'b': '%example.com%', 'c': '%example.org%'}
+        params = {"a": "Employee", "b": "%example.com%", "c": "%example.org%"}
         attr_map = {
-            ('userType', None, None): 'usertype',
-            ('emails', None, None): 'emails',
-            ('emails', 'value', None): 'emails.value',
+            ("userType", None, None): "usertype",
+            ("emails", None, None): "emails",
+            ("emails", "value", None): "emails.value",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         query = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
-        sql = "(usertype != {a}) AND (NOT ((emails LIKE {b}) OR (emails.value LIKE {c})))"
-        params = {'a': 'Employee', 'b': '%example.com%', 'c': '%example.org%'}
+        sql = (
+            "(usertype != {a}) AND (NOT ((emails LIKE {b}) OR (emails.value LIKE {c})))"
+        )
+        params = {"a": "Employee", "b": "%example.com%", "c": "%example.org%"}
         attr_map = {
-            ('userType', None, None): 'usertype',
-            ('emails', None, None): 'emails',
-            ('emails', 'value', None): 'emails.value',
+            ("userType", None, None): "usertype",
+            ("emails", None, None): "emails",
+            ("emails", "value", None): "emails.value",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_user_type_eq_and_not_email_type_eq_1(self):
         query = 'userType eq "Employee" and (emails.type eq "work")'
         sql = "usertype = {a}"
-        params = {'a': 'Employee'}
+        params = {"a": "Employee"}
         attr_map = {
-            ('userType', None, None): 'usertype',
+            ("userType", None, None): "usertype",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_user_type_eq_and_not_email_type_eq_2(self):
         query = 'userType eq "Employee" and (emails.type eq "work")'
         sql = "emails.type = {a}"
-        params = {'a': 'work'}
+        params = {"a": "work"}
         attr_map = {
-            ('emails', 'type', None): 'emails.type',
+            ("emails", "type", None): "emails.type",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains_1(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         sql = "usertype = {a}"
-        params = {'a': 'Employee'}
+        params = {"a": "Employee"}
         attr_map = {
-            ('userType', None, None): 'usertype',
+            ("userType", None, None): "usertype",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains_2(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         sql = "emails.type = {a}"
-        params = {'a': 'work'}
+        params = {"a": "work"}
         attr_map = {
-            ('emails', 'type', None): 'emails.type',
+            ("emails", "type", None): "emails.type",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains_3(self):
         query = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         sql = "(emails.type = {a}) AND (emails.value LIKE {b})"
-        params = {'a': 'work', 'b': '%@example.com%'}
+        params = {"a": "work", "b": "%@example.com%"}
         attr_map = {
-            ('emails', 'type', None): 'emails.type',
-            ('emails', 'value', None): 'emails.value',
+            ("emails", "type", None): "emails.type",
+            ("emails", "value", None): "emails.value",
         }
         self.assertSQL(query, sql, params, attr_map)
 
-    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_1(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_1(
+        self,
+    ):
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         sql = "(emails.value LIKE {a}) OR (ims.type = {b})"
-        params = {'a': '%@example.com%', 'b': 'xmpp'}
+        params = {"a": "%@example.com%", "b": "xmpp"}
         attr_map = {
-            ('emails', 'value', None): 'emails.value',
-            ('ims', 'type', None): 'ims.type',
+            ("emails", "value", None): "emails.value",
+            ("ims", "type", None): "ims.type",
         }
         self.assertSQL(query, sql, params, attr_map)
 
-    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_2(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_2(
+        self,
+    ):
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         sql = "(emails.value LIKE {a}) OR ((ims.type = {b}) AND (ims.value LIKE {c}))"
-        params = {'a': '%@example.com%', 'b': 'xmpp', 'c': '%@foo.com%'}
+        params = {"a": "%@example.com%", "b": "xmpp", "c": "%@foo.com%"}
         attr_map = {
-            ('emails', 'value', None): 'emails.value',
-            ('ims', 'type', None): 'ims.type',
-            ('ims', 'value', None): 'ims.value',
+            ("emails", "value", None): "emails.value",
+            ("ims", "type", None): "ims.type",
+            ("ims", "value", None): "ims.value",
         }
         self.assertSQL(query, sql, params, attr_map)
 
-    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_3(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_3(
+        self,
+    ):
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         sql = "((emails.type = {a}) AND (emails.value LIKE {b})) OR (ims.type = {c})"
-        params = {'a': 'work', 'b': '%@example.com%', 'c': 'xmpp'}
+        params = {"a": "work", "b": "%@example.com%", "c": "xmpp"}
         attr_map = {
-            ('emails', 'value', None): 'emails.value',
-            ('emails', 'type', None): 'emails.type',
-            ('ims', 'type', None): 'ims.type',
+            ("emails", "value", None): "emails.value",
+            ("emails", "type", None): "emails.type",
+            ("ims", "type", None): "ims.type",
         }
         self.assertSQL(query, sql, params, attr_map)
 
-    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_4(self):
-        query = ('emails[type eq "work" and value co "@example.com"] or '
-                 'ims[type eq "xmpp" and value co "@foo.com"]')
+    def test_emails_type_eq_work_value_contians_or_ims_type_eq_and_value_contians_4(
+        self,
+    ):
+        query = (
+            'emails[type eq "work" and value co "@example.com"] or '
+            'ims[type eq "xmpp" and value co "@foo.com"]'
+        )
         sql = "(emails.type = {a}) OR (ims.value LIKE {b})"
-        params = {'a': 'work', 'b': '%@foo.com%'}
+        params = {"a": "work", "b": "%@foo.com%"}
         attr_map = {
-            ('emails', 'type', None): 'emails.type',
-            ('ims', 'value', None): 'ims.value',
+            ("emails", "type", None): "emails.type",
+            ("ims", "value", None): "ims.value",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_email_type_eq_primary_value_eq_uuid_1(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         sql = "emails.value = {a}"
-        params = {'a': '001750ca-8202-47cd-b553-c63f4f245940'}
+        params = {"a": "001750ca-8202-47cd-b553-c63f4f245940"}
         attr_map = {
-            ('emails', 'value', None): 'emails.value',
+            ("emails", "value", None): "emails.value",
         }
         self.assertSQL(query, sql, params, attr_map)
 
     def test_email_type_eq_primary_value_eq_uuid_2(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         sql = "emails.type = {a}"
-        params = {'a': 'Primary'}
+        params = {"a": "Primary"}
         attr_map = {
-            ('emails', 'type', None): 'emails.type',
+            ("emails", "type", None): "emails.type",
         }
         self.assertSQL(query, sql, params, attr_map)
 
 
 class AzureQueries(SetupHelper, TestCase):
     attr_map = {
-        ('emails', 'type', None): 'emails.type',
-        ('emails', 'value', None): 'emails.value',
-        ('externalId', None, None): 'externalid',
+        ("emails", "type", None): "emails.type",
+        ("emails", "value", None): "emails.value",
+        ("externalId", None, None): "externalid",
     }
 
     def test_email_type_eq_primary_value_eq_uuid(self):
-        query = 'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        query = (
+            'emails[type eq "Primary"].value eq "001750ca-8202-47cd-b553-c63f4f245940"'
+        )
         sql = "(emails.type = {a} AND emails.value = {b})"
-        params = {'a': 'Primary', 'b': '001750ca-8202-47cd-b553-c63f4f245940'}
+        params = {"a": "Primary", "b": "001750ca-8202-47cd-b553-c63f4f245940"}
         self.assertSQL(query, sql, params)
 
     def test_external_id_from_azure(self):
         query = 'externalId eq "4d32ab19-ae09-4236-82fa-15768bc48a08"'
         sql = "externalid = {a}"
-        params = {'a': '4d32ab19-ae09-4236-82fa-15768bc48a08'}
+        params = {"a": "4d32ab19-ae09-4236-82fa-15768bc48a08"}
         self.assertSQL(query, sql, params)
 
     def test_parse_simple_email_filter_with_uuid(self):
         query = 'emails.value eq "001750ca-8202-47cd-b553-c63f4f245940"'
         sql = "emails.value = {a}"
-        params = {'a': '001750ca-8202-47cd-b553-c63f4f245940'}
+        params = {"a": "001750ca-8202-47cd-b553-c63f4f245940"}
         self.assertSQL(query, sql, params)
 
 
 class GitHubBugsQueries(SetupHelper, TestCase):
     attr_map = {
-        ('emails', 'type', None): 'emails.type',
+        ("emails", "type", None): "emails.type",
     }
 
     def test_g15_ne_op(self):
         query = 'emails[type ne "work"]'
         sql = "emails.type != {a}"
-        params = {'a': 'work'}
+        params = {"a": "work"}
         self.assertSQL(query, sql, params)
 
 
@@ -418,10 +449,6 @@ class CommandLine(TestCase):
 
     def test_command_line(self):
         transpile_sql.main(['userName eq "bjensen"'])
-        result = self.test_stdout.getvalue().strip().split('\n')
-        expected = [
-            'SQL: UPPER(username) = UPPER({a})',
-            "PARAMS: {'a': 'bjensen'}"
-        ]
+        result = self.test_stdout.getvalue().strip().split("\n")
+        expected = ["SQL: UPPER(username) = UPPER({a})", "PARAMS: {'a': 'bjensen'}"]
         self.assertEqual(result, expected)
-

--- a/tests/test_transpiler_django.py
+++ b/tests/test_transpiler_django.py
@@ -113,16 +113,16 @@ class TestRFCExamples(TestCase):
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         scim = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         django = Q(usertype__iexact="Employee") & (
-                Q(emails__icontains="example.com")
-                | Q(emails__value__icontains="example.org")
+            Q(emails__icontains="example.com")
+            | Q(emails__value__icontains="example.org")
         )
         self.assert_q(scim, django)
 
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         scim = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
         django = ~Q(usertype__iexact="Employee") & ~(
-                Q(emails__icontains="example.com")
-                | Q(emails__value__icontains="example.org")
+            Q(emails__icontains="example.com")
+            | Q(emails__value__icontains="example.org")
         )
         self.assert_q(scim, django)
 
@@ -134,7 +134,7 @@ class TestRFCExamples(TestCase):
     def test_user_type_eq_and_not_email_type_eq_work_and_value_contains(self):
         scim = 'userType eq "Employee" and emails[type eq "work" and value co "@example.com"]'
         django = Q(usertype__iexact="Employee") & (
-                Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
+            Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
         )
         self.assert_q(scim, django)
 
@@ -144,8 +144,8 @@ class TestRFCExamples(TestCase):
             'ims[type eq "xmpp" and value co "@foo.com"]'
         )
         django = (
-                         Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
-                 ) | (Q(ims__type__iexact="xmpp") & Q(ims__value__icontains="@foo.com"))
+            Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
+        ) | (Q(ims__type__iexact="xmpp") & Q(ims__value__icontains="@foo.com"))
 
         self.assert_q(scim, django)
 
@@ -181,8 +181,8 @@ class TestUndefinedAttributes(TestCase):
     def test_user_type_eq_and_email_contains_or_email_contains(self):
         scim = 'userType eq "Employee" and (emails co "example.com" or emails.value co "example.org")'
         django = Q(usertype__iexact="Employee") & (
-                Q(emails__icontains="example.com")
-                | Q(emails__value__icontains="example.org")
+            Q(emails__icontains="example.com")
+            | Q(emails__value__icontains="example.org")
         )
         attr_map = {
             ("userType", None, None): "usertype",
@@ -194,8 +194,8 @@ class TestUndefinedAttributes(TestCase):
     def test_user_type_ne_and_not_email_contains_or_email_contains(self):
         scim = 'userType ne "Employee" and not (emails co "example.com" or emails.value co "example.org")'
         django = ~Q(usertype__iexact="Employee") & ~(
-                Q(emails__icontains="example.com")
-                | Q(emails__value__icontains="example.org")
+            Q(emails__icontains="example.com")
+            | Q(emails__value__icontains="example.org")
         )
         attr_map = {
             ("userType", None, None): "usertype",
@@ -240,7 +240,7 @@ class TestUndefinedAttributes(TestCase):
         self.assert_q(scim, attr_map, django)
 
     def test_emails_type_eq_work_value_contains_or_ims_type_eq_and_value_contains_1(
-            self,
+        self,
     ):
         scim = (
             'emails[type eq "work" and value co "@example.com"] or '
@@ -256,14 +256,14 @@ class TestUndefinedAttributes(TestCase):
         self.assert_q(scim, attr_map, django)
 
     def test_emails_type_eq_work_value_contains_or_ims_type_eq_and_value_contains_2(
-            self,
+        self,
     ):
         scim = (
             'emails[type eq "work" and value co "@example.com"] or '
             'ims[type eq "xmpp" and value co "@foo.com"]'
         )
         django = Q(emails__value__icontains="@example.com") | (
-                Q(ims__type__iexact="xmpp") & Q(ims__value__icontains="@foo.com")
+            Q(ims__type__iexact="xmpp") & Q(ims__value__icontains="@foo.com")
         )
         attr_map = {
             ("emails", "value", None): "emails.value",
@@ -273,15 +273,15 @@ class TestUndefinedAttributes(TestCase):
         self.assert_q(scim, attr_map, django)
 
     def test_emails_type_eq_work_value_contains_or_ims_type_eq_and_value_contains_3(
-            self,
+        self,
     ):
         scim = (
             'emails[type eq "work" and value co "@example.com"] or '
             'ims[type eq "xmpp" and value co "@foo.com"]'
         )
         django = (
-                         Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
-                 ) | Q(ims__type__iexact="xmpp")
+            Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
+        ) | Q(ims__type__iexact="xmpp")
         attr_map = {
             ("emails", "value", None): "emails.value",
             ("emails", "type", None): "emails.type",
@@ -290,7 +290,7 @@ class TestUndefinedAttributes(TestCase):
         self.assert_q(scim, attr_map, django)
 
     def test_emails_type_eq_work_value_contains_or_ims_type_eq_and_value_contains_4(
-            self,
+        self,
     ):
         scim = (
             'emails[type eq "work" and value co "@example.com"] or '

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ basepython =
 commands =
     poetry install -v --extras "django-query"
     poetry run ruff check src
+    poetry run ruff format --check --diff src
 
 [testenv:coverage]
 basepython =


### PR DESCRIPTION
Almost all of this repository was *already* using Black-style
formatting, despite there not actually being enforcement of style in CI.

Ruff's autoformatter is outrageously fast and (with small differences)
produces code formatted in the same style as Black.

Let's turn on the autoformatter!

This change was produced by:

1. Editing `pyproject.toml` and `tox.ini` to opt into `ruff format`
2. Changing `noqa F821` to `noqa: F821` (missing the colon means that
   *all* lint rules are ignored)
3. Running `ruff format .`
4. Moving `noqa` comments as necessary!
   ```
   ruff --fix .
   ruff --add-noqa .
   ```

Unfortunately, ruff doesn't allow telling the autoformatter to skip an
enforcement of quote style, so this diff is largely just changing quote
characters.