### PR TITLE
Use exact when comparing against boolean values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 CHANGE LOG
 ==========
 
+0.6.0
+----
+- Use "exact" on equality checks against boolean values. #53
+
 0.5.1
 -----
 - Add support for Python 3.12
@@ -101,4 +105,3 @@ match rows now!
 -----
 
 - attr_map keys now control which SQL expressions are present in output of transpiler
-

--- a/src/scim2_filter_parser/transpilers/django_q_object.py
+++ b/src/scim2_filter_parser/transpilers/django_q_object.py
@@ -231,10 +231,10 @@ class Transpiler(ast.NodeTransformer):
         if not op:
             raise ValueError(f"Unknown Django op {op_code}")
 
-        if isinstance(comp_value, bool) and op == 'iexact':
+        if isinstance(comp_value, bool) and op == "iexact":
             # Use "exact" for boolean values, as certain DB drivers (e.g., Postgres) will transpile
             #  "<field> iexact true/false" to "UPPER(field::text) = UPPER(true/false), which fails.
             #  UPPER requires a string.
-            return 'exact'
+            return "exact"
 
         return op or node_value

--- a/tests/test_transpiler_django.py
+++ b/tests/test_transpiler_django.py
@@ -18,6 +18,7 @@ class TestRFCExamples(TestCase):
         ("meta", "lastModified", None): "meta.lastmodified",
         ("ims", "type", None): "ims.type",
         ("ims", "value", None): "ims.value",
+        ("active", None, None): "is_active",
     }
 
     def assert_q(self, input, expected):
@@ -55,12 +56,12 @@ class TestRFCExamples(TestCase):
 
     def test_username_eq_true(self):
         scim = 'userName eq "true"'
-        django = Q(username__iexact=True)
+        django = Q(username__exact=True)
         self.assert_q(scim, django)
 
     def test_username_eq_false(self):
         scim = 'userName eq "false"'
-        django = Q(username__iexact=False)
+        django = Q(username__exact=False)
         self.assert_q(scim, django)
 
     def test_schema_username_startswith(self):
@@ -147,6 +148,11 @@ class TestRFCExamples(TestCase):
             Q(emails__type__iexact="work") & Q(emails__value__icontains="@example.com")
         ) | (Q(ims__type__iexact="xmpp") & Q(ims__value__icontains="@foo.com"))
 
+        self.assert_q(scim, django)
+
+    def test_active_eq_true(self) -> None:
+        scim = 'active eq true'
+        django = Q(is_active__exact=True)
         self.assert_q(scim, django)
 
 


### PR DESCRIPTION
Closes #49 

Equality predicates against boolean values will now transpile to `Q(fieldX__exact=True/False)`. This avoids using the SQL UPPER function, which at least in PostgreSQL fails, as the function requires a string as input.

`Transpiler.lookup_op` now takes the comparison value as well, and uses both the SCIM operation and the comparison value to decide on the appropriate Django operator.