### PR TITLE
Use exact Django operator on equality checks against empty strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 CHANGE LOG
 ==========
 
+0.7.0
+----
+- Use "exact" on equality checks against empty strings. #51
+
 0.6.0
 ----
 - Use "exact" on equality checks against boolean values. #53

--- a/src/scim2_filter_parser/transpilers/django_q_object.py
+++ b/src/scim2_filter_parser/transpilers/django_q_object.py
@@ -233,16 +233,16 @@ class Transpiler(ast.NodeTransformer):
 
         if isinstance(comp_value, bool) and op == "iexact":
             # Use "exact" for boolean values, as certain DB drivers (e.g., Postgres) will transpile
-            #  "<field> iexact true/false" to "UPPER(field::text) = UPPER(true/false), which fails.
-            #  UPPER requires a string.
+            # "<field> iexact true/false" to "UPPER(field::text) = UPPER(true/false), which fails.
+            # UPPER requires a string.
             return "exact"
         if comp_value == "" and op == "iexact":
             # In Oracle iexact + empty string will never evaluate to true. I.e., TRIM(' ') != '' and
-            #  UPPER(TRIM('')) != UPPER(''). Furthermore, case-insensitive search against an empty
-            #  string has no added value over a case-sensitive search. Hence, whenever the SCIM
-            #  path is '<field> eq ""', rather than doing field__iexact='', we do field=''. The
-            #  oracle Django driver will then convert field='' into "field" IS NULL, which is the
-            #  correct way to do it in Oracle.
+            # UPPER(TRIM('')) != UPPER(''). Furthermore, case-insensitive search against an empty
+            # string has no added value over a case-sensitive search. Hence, whenever the SCIM
+            # path is '<field> eq ""', rather than doing field__iexact='', we do field=''. The
+            # oracle Django driver will then convert field='' into "field" IS NULL, which is the
+            # correct way to do it in Oracle.
             return "exact"
 
         return op or node_value

--- a/tests/test_transpiler_django.py
+++ b/tests/test_transpiler_django.py
@@ -354,3 +354,17 @@ class TestAzureQueries(TestCase):
         scim = 'emails.value eq "001750ca-8202-47cd-b553-c63f4f245940"'
         django = Q(emails__value__iexact="001750ca-8202-47cd-b553-c63f4f245940")
         self.assert_q(scim, django)
+
+
+class TestOracleQueries(TestCase):
+    attr_map = {
+        ("externalId", None, None): "externalid",
+    }
+
+    def assert_q(self, input, expected):
+        self.assertEqual(expected, get_query(input, self.attr_map))
+
+    def test_empty_string_equality_transpiles_to_exact(self):
+        scim = 'externalId eq ""'
+        django = Q(externalid__exact="")
+        self.assert_q(scim, django)


### PR DESCRIPTION
Closes https://github.com/15five/scim2-filter-parser/issues/51

Equality predicates against empty strings will now transpile to `Q(fieldX__exact="")`. This prevents queries such as `UPPER(TRIM('')) != UPPER('')`, which at least in Oracle, always evaluate to `False`.