### PR TITLE
Fix NUMBER parsing for numbers more than single digit :-)

### DIFF
--- a/src/scim2_filter_parser/lexer.py
+++ b/src/scim2_filter_parser/lexer.py
@@ -202,7 +202,7 @@ class SCIMLexer(Lexer):
     FALSE = r"false"
     TRUE = r"true"
     NULL = r"null"
-    NUMBER = r"[0-9]"  # only support integers at this time
+    NUMBER = r"[0-9]+"  # only support integers at this time
 
     # attrPath parts
     @_(r"[a-zA-Z]+:[a-zA-Z0-9:\._-]+:")


### PR DESCRIPTION
I stumbled on this during my own application stress testing, these queries where failing...
(age := 30)
PS. Filter is my AST geared Parser

```
    def test_numeric_operators(self):
        # Greater than
        filter_obj = Filter('age gt 20')
        assert filter_obj.match(self.user) is True

        # Greater than or equal
        filter_obj = Filter('age ge 30')
        assert filter_obj.match(self.user) is True

        # Less than
        filter_obj = Filter('age lt 40')
        assert filter_obj.match(self.user) is True

        # Less than or equal
        filter_obj = Filter('age le 30')
        assert filter_obj.match(self.user) is True
```