### PR TITLE
chore: Move cloudcov to coveralls

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -48,6 +48,9 @@ jobs:
       - uses: actions/checkout@v4
       - run: pip install -U tox poetry
       - run: tox -e coverage
-      - uses: "codecov/codecov-action@v3"
+      - uses: coverallsapp/github-action@v2
         with:
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml
+          format: cobertura
+          fail-on-error: true


### PR DESCRIPTION
This pull request updates the CI/CD workflow to switch the code coverage reporting tool from Codecov to Coveralls, and adjusts the configuration to match the requirements of the new tool.

**CI/CD workflow updates:**

* Replaced the `codecov/codecov-action@v3` step with `coverallsapp/github-action@v2` in `.github/workflows/cicd.yml`, updating the configuration to use the appropriate token, coverage file, and format for Coveralls.